### PR TITLE
Allow multiple admin emails

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,13 @@ const App = () => {
 
   if (isLoading) return <p>Loading...</p>;
 
-  const allowedAdmins = ["atlashomeskphb@gmail.com"];
+  // Allowlist of emails permitted to access the admin portal
+  const allowedAdmins = [
+    "atlashomeskphb@gmail.com",
+    "sreekar.atla@gmail.com",
+    "aruna.atla@live.com",
+    "ashokreddy343@gmail.com",
+  ];
   const isAuthorized = isAuthenticated && allowedAdmins.includes(user?.email);
   
 


### PR DESCRIPTION
## Summary
- allow multiple admin email addresses for accessing the portal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685be9ada584832bbe34d3381d3cadf7