### PR TITLE
Enable editing bookings by pre-filling form

### DIFF
--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -30,6 +30,8 @@ const Bookings = () => {
     createdAt: today,      // Default to today
     paymentDate: today     // Default to today
   });
+  const [formMode, setFormMode] = useState('create');
+  const [selectedBookingId, setSelectedBookingId] = useState(null);
   const [filters, setFilters] = useState({
     listing: '',
     guest: '',
@@ -89,6 +91,8 @@ const Bookings = () => {
   const reset = () => {
     setGuest({ name: '', phone: '', email: '', idProofUrl: '' });
     setSelectedGuestId('');
+    setFormMode('create');
+    setSelectedBookingId(null);
     setBooking({
       id: null,
       listingId: '',
@@ -131,16 +135,15 @@ const Bookings = () => {
         createdAt: booking.createdAt,
         paymentDate: booking.paymentDate
       };
-      // Remove id if it's null or undefined (for create)
-      if (!booking.id) {
-        const { id, ...rest } = payload;
-        payload = rest;
-      }
-      if (booking.id) {
-        await axios.put(`${import.meta.env.VITE_API_BASE}/bookings/${booking.id}`, payload);
+      if (formMode === 'edit' && selectedBookingId) {
+        await axios.put(
+          `${import.meta.env.VITE_API_BASE}/bookings/${selectedBookingId}`,
+          payload
+        );
         setSuccessMsg('Booking updated successfully!');
       } else {
-        await axios.post(`${import.meta.env.VITE_API_BASE}/bookings`, payload);
+        const { id, ...createPayload } = payload;
+        await axios.post(`${import.meta.env.VITE_API_BASE}/bookings`, createPayload);
         setSuccessMsg('Booking created successfully!');
       }
       reset();
@@ -157,6 +160,8 @@ const Bookings = () => {
   };
 
   const handleEdit = (bookingToEdit) => {
+    setFormMode('edit');
+    setSelectedBookingId(bookingToEdit.id);
     setBooking({
       id: bookingToEdit.id,
       listingId: bookingToEdit.listingId || '',
@@ -220,11 +225,16 @@ const Bookings = () => {
 
   return (
     <Box>
-      <Card sx={{ mx: 'auto', mt: 2, mb: 2 }}>
+      <Card sx={{ mx: 'auto', mt: 2, mb: 2, bgcolor: formMode === 'edit' ? '#fffbe6' : 'inherit' }}>
         <CardContent>
           <Typography variant="h4" component="h2" gutterBottom>
-            {booking.id ? 'Edit Booking' : 'Create Booking'}
+            {formMode === 'edit' ? 'Edit Booking' : 'Create Booking'}
           </Typography>
+          {formMode === 'edit' && (
+            <Typography variant="subtitle2" color="secondary" gutterBottom>
+              Edit Mode
+            </Typography>
+          )}
 
           <Box ref={messageRef} sx={{ mb: 2 }}>
             {successMsg && (
@@ -276,7 +286,7 @@ const Bookings = () => {
                 <Select
                   value={selectedGuestId}
                   onChange={e => setSelectedGuestId(e.target.value)}
-                  disabled={Boolean(booking.id)}
+                  disabled={formMode === 'edit'}
                   label="Guest"
                 >
                   <MenuItem value="">New Guest</MenuItem>
@@ -304,7 +314,7 @@ const Bookings = () => {
                   placeholder="Guest Name"
                   value={guest.name}
                   onChange={e => setGuest({ ...guest, name: e.target.value })}
-                  disabled={!!selectedGuestId || !!booking.id}
+                  disabled={!!selectedGuestId || formMode === 'edit'}
                 />
               )}
 
@@ -315,7 +325,7 @@ const Bookings = () => {
                   placeholder="Phone"
                   value={guest.phone}
                   onChange={e => setGuest({ ...guest, phone: e.target.value })}
-                  disabled={!!selectedGuestId || !!booking.id}
+                  disabled={!!selectedGuestId || formMode === 'edit'}
                   inputProps={{
                     pattern: "^[0-9+\\-\\s]{7,15}$",
                     title: "Enter a valid phone number"
@@ -340,7 +350,7 @@ const Bookings = () => {
                   type="email"
                   value={guest.email}
                   onChange={e => setGuest({ ...guest, email: e.target.value })}
-                  disabled={!!selectedGuestId || !!booking.id}
+                  disabled={!!selectedGuestId || formMode === 'edit'}
                   inputProps={{
                     title: "Enter a valid email address"
                   }}
@@ -354,7 +364,7 @@ const Bookings = () => {
                   placeholder="ID Proof URL"
                   value={guest.idProofUrl}
                   onChange={e => setGuest({ ...guest, idProofUrl: e.target.value })}
-                  disabled={!!selectedGuestId || !!booking.id}
+                  disabled={!!selectedGuestId || formMode === 'edit'}
                 />
               )}
 
@@ -475,7 +485,7 @@ const Bookings = () => {
               />
 
               {/* Created At - only show if not editing */}
-              {!booking.id && (
+              {formMode !== 'edit' && (
                 <TextField
                   label="Created At"
                   type="date"
@@ -486,7 +496,7 @@ const Bookings = () => {
               )}
 
               {/* Payment Date - only show if not editing */}
-              {!booking.id && (
+              {formMode !== 'edit' && (
                 <TextField
                   label="Payment Date"
                   type="date"
@@ -510,10 +520,10 @@ const Bookings = () => {
                 disabled={loading}
                 sx={{ minWidth: 120 }}
               >
-                {loading ? 'Saving...' : booking.id ? 'Update Booking' : 'Create Booking'}
+                {loading ? 'Saving...' : formMode === 'edit' ? 'Update Booking' : 'Create Booking'}
               </Button>
 
-              {booking.id && (
+              {formMode === 'edit' && (
                 <Button
                   type="button"
                   variant="outlined"


### PR DESCRIPTION
## Summary
- add form state for create vs edit mode
- pre-fill booking form when clicking **Edit**
- highlight the form in edit mode
- update Save/Cancel logic to update the selected booking

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685bebfad08c832b873b3bc0b3f96ec9