### PR TITLE
Update admin report endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Set `VITE_API_BASE` in your `.env` file to the base URL of the Atlas API. The
 reports page fetches data from REST endpoints such as:
 
 ```
-GET /reports/earnings/monthly
-GET /reports/payouts/daily
-GET /reports/bookings/calendar
+GET /admin/reports/earnings/monthly
+GET /admin/reports/payouts/daily
+GET /admin/reports/bookings/calendar
 ```
 
 If these endpoints are unavailable the application will automatically fall back
-to the standard `/bookings`, `/listings` and `/payouts` endpoints.
+to the standard `/admin/reports/bookings`, `/admin/reports/listings` and
+`/admin/reports/payouts` endpoints.
 
 # Go to the directory where you want to store all repos
 cd ~/Projects/AtlasHomestays  # or any preferred location

--- a/src/components/CustomReportGenerator.jsx
+++ b/src/components/CustomReportGenerator.jsx
@@ -20,8 +20,12 @@ function CustomReportGenerator() {
     async function fetchData() {
       try {
         const [listRes, bookRes] = await Promise.all([
-          axios.get(`${import.meta.env.VITE_API_BASE}/listings`),
-          axios.get(`${import.meta.env.VITE_API_BASE}/bookings`)
+          axios.get(
+            `${import.meta.env.VITE_API_BASE}/admin/reports/listings`
+          ),
+          axios.get(
+            `${import.meta.env.VITE_API_BASE}/admin/reports/bookings`
+          )
         ]);
         setListings(listRes.data.map(l => l.name));
         const listingMap = {};

--- a/src/components/DailyPayoutReport.jsx
+++ b/src/components/DailyPayoutReport.jsx
@@ -32,13 +32,13 @@ function DailyPayoutReport() {
     async function fetchData() {
       try {
         const res = await axios.get(
-          `${import.meta.env.VITE_API_BASE}/reports/payouts/daily`
+          `${import.meta.env.VITE_API_BASE}/admin/reports/payouts/daily`
         );
         setPayoutData(res.data);
       } catch (err) {
         console.warn('Falling back to /payouts', err);
         axios
-          .get(`${import.meta.env.VITE_API_BASE}/payouts`)
+          .get(`${import.meta.env.VITE_API_BASE}/admin/reports/payouts`)
           .then((res) => setPayoutData(res.data))
           .catch((err2) => console.error(err2));
       }

--- a/src/components/EarningsReport.jsx
+++ b/src/components/EarningsReport.jsx
@@ -26,13 +26,15 @@ function EarningsReport() {
     async function fetchData() {
       try {
         const res = await axios.get(
-          `${import.meta.env.VITE_API_BASE}/reports/earnings/monthly`
+          `${import.meta.env.VITE_API_BASE}/admin/reports/earnings/monthly`
         );
         setData(res.data);
       } catch (err) {
         console.warn('Falling back to client aggregation', err);
         try {
-          const res = await axios.get(`${import.meta.env.VITE_API_BASE}/bookings`);
+          const res = await axios.get(
+            `${import.meta.env.VITE_API_BASE}/admin/reports/bookings`
+          );
           const months = buildEmptyMonths();
           res.data.forEach((b) => {
             const key = dayjs(b.paymentDate || b.createdAt).format('YYYY-MM');

--- a/src/components/MonthlyEarningsReport.jsx
+++ b/src/components/MonthlyEarningsReport.jsx
@@ -57,8 +57,12 @@ function MonthlyEarningsReport() {
     async function fetchData() {
       try {
         const [bookRes, listRes] = await Promise.all([
-          axios.get(`${import.meta.env.VITE_API_BASE}/bookings`),
-          axios.get(`${import.meta.env.VITE_API_BASE}/listings`)
+          axios.get(
+            `${import.meta.env.VITE_API_BASE}/admin/reports/bookings`
+          ),
+          axios.get(
+            `${import.meta.env.VITE_API_BASE}/admin/reports/listings`
+          )
         ]);
         setEarningsData(aggregateData(bookRes.data, listRes.data));
       } catch (err) {

--- a/src/components/MultiCalendarEarningsReport.jsx
+++ b/src/components/MultiCalendarEarningsReport.jsx
@@ -18,15 +18,19 @@ function MultiCalendarEarningsReport() {
     async function fetchData() {
       try {
         const res = await axios.get(
-          `${import.meta.env.VITE_API_BASE}/reports/bookings/calendar`
+          `${import.meta.env.VITE_API_BASE}/admin/reports/bookings/calendar`
         );
         setListings(res.data);
       } catch (err) {
         console.warn('Falling back to client aggregation', err);
         try {
           const [listRes, bookRes] = await Promise.all([
-            axios.get(`${import.meta.env.VITE_API_BASE}/listings`),
-            axios.get(`${import.meta.env.VITE_API_BASE}/bookings`)
+            axios.get(
+              `${import.meta.env.VITE_API_BASE}/admin/reports/listings`
+            ),
+            axios.get(
+              `${import.meta.env.VITE_API_BASE}/admin/reports/bookings`
+            )
           ]);
           const map = {};
           const listObjects = listRes.data.map((l) => ({

--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -28,7 +28,7 @@ function SingleCalendarEarningsReport() {
     async function fetchData() {
       try {
         const res = await axios.get(
-          `${import.meta.env.VITE_API_BASE}/reports/bookings/calendar`
+          `${import.meta.env.VITE_API_BASE}/admin/reports/bookings/calendar`
         );
         setEvents(
           res.data.map((e) => ({
@@ -41,8 +41,12 @@ function SingleCalendarEarningsReport() {
         console.warn('Falling back to client aggregation', err);
         try {
           const [bookRes, listRes] = await Promise.all([
-            axios.get(`${import.meta.env.VITE_API_BASE}/bookings`),
-            axios.get(`${import.meta.env.VITE_API_BASE}/listings`)
+            axios.get(
+              `${import.meta.env.VITE_API_BASE}/admin/reports/bookings`
+            ),
+            axios.get(
+              `${import.meta.env.VITE_API_BASE}/admin/reports/listings`
+            )
           ]);
           const listingMap = {};
           listRes.data.forEach((l) => {


### PR DESCRIPTION
## Summary
- update README with new admin routes
- use new `/admin/reports` API prefix across report components

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c46f5e9f0832b96ee09b5f5eeecd1