### PR TITLE
Update earnings chart with net vs fees

### DIFF
--- a/src/components/EarningsReport.jsx
+++ b/src/components/EarningsReport.jsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
 } from 'recharts';
 import dayjs from 'dayjs';
 import axios from 'axios';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE;
 
 function buildEmptyMonths() {
   const months = {};
@@ -11,82 +20,97 @@ function buildEmptyMonths() {
     const d = dayjs().subtract(i, 'month');
     months[d.format('YYYY-MM')] = {
       month: d.format('MMM'),
-      gross: 0,
-      fees: 0,
-      net: 0
+      totalGross: 0,
+      totalFees: 0,
+      totalNet: 0,
     };
   }
   return months;
 }
 
 function EarningsReport() {
-  const [earningsData, setEarningsData] = useState([]);
+  const [monthlyData, setMonthlyData] = useState([]);
 
   useEffect(() => {
-    async function fetchData() {
+    async function fetchMonthlyEarnings() {
       try {
-        const res = await axios.get(
-          `${import.meta.env.VITE_API_BASE}/admin/reports/earnings/monthly`
-        );
-        const normalized = Array.isArray(res.data)
-          ? res.data.map((entry) => ({
+        const res = await fetch(`${API_BASE_URL}/admin/reports/earnings/monthly`);
+        const data = await res.json();
+        const normalized = Array.isArray(data)
+          ? data.map((entry) => ({
               month: dayjs(entry.month).format('MMM'),
-              gross: entry.totalGross,
-              fees: entry.totalFees,
-              net: entry.totalNet,
+              totalGross: entry.totalGross,
+              totalFees: entry.totalFees,
+              totalNet: entry.totalNet,
             }))
           : [];
-        setEarningsData(normalized);
-        console.log('earningsData', normalized);
+        setMonthlyData(normalized);
       } catch (err) {
         console.warn('Falling back to client aggregation', err);
         try {
           const res = await axios.get(
-            `${import.meta.env.VITE_API_BASE}/admin/reports/bookings`
+            `${API_BASE_URL}/admin/reports/bookings`
           );
           const months = buildEmptyMonths();
           res.data.forEach((b) => {
             const key = dayjs(b.paymentDate || b.createdAt).format('YYYY-MM');
             if (months[key]) {
               const amt = parseFloat(b.amountReceived) || 0;
-              months[key].gross += amt;
-              months[key].net += amt;
+              months[key].totalGross += amt;
+              months[key].totalNet += amt;
             }
           });
           const aggregated = Object.values(months);
-          setEarningsData(aggregated);
-          console.log("earningsData", aggregated);
+          setMonthlyData(aggregated);
         } catch (err2) {
           console.error(err2);
         }
       }
     }
-    fetchData();
+    fetchMonthlyEarnings();
   }, []);
 
-  console.log("earningsData", earningsData);
-
-  if (!Array.isArray(earningsData) || earningsData.length === 0) {
+  if (!Array.isArray(monthlyData) || monthlyData.length === 0) {
     return <p>No data available</p>;
   }
 
   return (
     <div style={{ width: '100%', height: 500 }}>
       <h2>📈 12-Month On-Month Earnings Report</h2>
-      <ResponsiveContainer>
+      <ResponsiveContainer width="100%" height={400}>
         <BarChart
-          data={earningsData}
+          data={monthlyData}
           margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
         >
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" />
           <YAxis />
-          <Tooltip formatter={(value) => `$${value}`} />
+          <Tooltip formatter={(value) => `₹${Number(value).toLocaleString()}`} />
           <Legend />
-          <Bar dataKey="gross" fill="#8884d8" name="Gross Earnings" />
-          <Bar dataKey="net" fill="#82ca9d" name="Net Payout" />
+          <Bar dataKey="totalNet" stackId="a" fill="#4caf50" name="Net Earnings" />
+          <Bar dataKey="totalFees" stackId="a" fill="#f44336" name="Commissions" />
         </BarChart>
       </ResponsiveContainer>
+      <table>
+        <thead>
+          <tr>
+            <th>Month</th>
+            <th>Total Gross</th>
+            <th>Total Fees</th>
+            <th>Total Net</th>
+          </tr>
+        </thead>
+        <tbody>
+          {monthlyData.map((row) => (
+            <tr key={row.month}>
+              <td>{row.month}</td>
+              <td>₹{Number(row.totalGross).toLocaleString()}</td>
+              <td>₹{Number(row.totalFees).toLocaleString()}</td>
+              <td>₹{Number(row.totalNet).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch data keys to totalNet, totalFees, totalGross
- show stacked bars for net earnings and commissions
- add summary table beneath the chart

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e4cd29d28832b965973a901a17c30