### PR TITLE
Fix layout of report sections

### DIFF
--- a/src/components/EarningsReport.jsx
+++ b/src/components/EarningsReport.jsx
@@ -85,7 +85,13 @@ function EarningsReport() {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" />
           <YAxis />
-          <Tooltip formatter={(value) => `₹${Number(value).toLocaleString()}`} />
+          <Tooltip
+            formatter={(value) =>
+              `₹${Number(value).toLocaleString('en-IN', {
+                minimumFractionDigits: 2,
+              })}`
+            }
+          />
           <Legend />
           <Bar dataKey="totalNet" stackId="a" fill="#4caf50" name="Net Earnings" />
           <Bar dataKey="totalFees" stackId="a" fill="#f44336" name="Commissions" />
@@ -104,9 +110,21 @@ function EarningsReport() {
           {monthlyData.map((row) => (
             <tr key={row.month}>
               <td>{row.month}</td>
-              <td>₹{Number(row.totalGross).toLocaleString()}</td>
-              <td>₹{Number(row.totalFees).toLocaleString()}</td>
-              <td>₹{Number(row.totalNet).toLocaleString()}</td>
+              <td>
+                ₹{row.totalGross.toLocaleString('en-IN', {
+                  minimumFractionDigits: 2,
+                })}
+              </td>
+              <td>
+                ₹{row.totalFees.toLocaleString('en-IN', {
+                  minimumFractionDigits: 2,
+                })}
+              </td>
+              <td>
+                ₹{row.totalNet.toLocaleString('en-IN', {
+                  minimumFractionDigits: 2,
+                })}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -7,24 +7,31 @@ import SingleCalendarEarningsReport from '../components/SingleCalendarEarningsRe
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import MultiCalendarEarningsReport from '../components/MultiCalendarEarningsReport';
-import { Stack } from '@mui/material';
 
 const Reports = () => {
     return (
         <div>
             <h1>Reports Page</h1>
-            <Stack spacing={2}>
+            <section style={{ marginBottom: '2rem' }}>
                 <EarningsReport />
+            </section>
+            <section style={{ marginBottom: '2rem' }}>
                 <DailyPayoutReport />
+            </section>
+            <section style={{ marginBottom: '2rem' }}>
                 <MonthlyEarningsReport />
-                <LocalizationProvider dateAdapter={AdapterDayjs}>
-                    <Stack spacing={2}>
-                        <CustomReportGenerator />
-                        <SingleCalendarEarningsReport />
-                        <MultiCalendarEarningsReport/>
-                    </Stack>
-                </LocalizationProvider>
-            </Stack>
+            </section>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <section style={{ marginBottom: '2rem' }}>
+                    <CustomReportGenerator />
+                </section>
+                <section style={{ marginBottom: '2rem' }}>
+                    <SingleCalendarEarningsReport />
+                </section>
+                <section style={{ marginBottom: '2rem' }}>
+                    <MultiCalendarEarningsReport />
+                </section>
+            </LocalizationProvider>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add spacing by wrapping each report in a `<section>` on the Reports page
- format currency values in the earnings report

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e4ef28bc8832b9695d1d5d5dce89e