### PR TITLE
Fix edit date pre-fill

### DIFF
--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import dayjs from 'dayjs';
 import {
   Box, Button, CircularProgress, FormControl, InputLabel, MenuItem,
   Select, TextField, Typography, Table, TableHead, TableRow, TableCell,
@@ -162,15 +163,19 @@ const Bookings = () => {
   };
 
   const handleEdit = (bookingToEdit) => {
+    console.log('Editing booking', bookingToEdit);
     setFormMode('edit');
     setSelectedBookingId(bookingToEdit.id);
     setBooking({
       id: bookingToEdit.id,
       listingId: bookingToEdit.listingId || '',
       // Support both camelCase variations returned from the API
-      checkinDate: bookingToEdit.checkinDate || bookingToEdit.checkInDate || '',
-      checkoutDate:
-        bookingToEdit.checkoutDate || bookingToEdit.checkOutDate || '',
+      checkinDate: (bookingToEdit.checkinDate || bookingToEdit.checkInDate)
+        ? dayjs(bookingToEdit.checkinDate || bookingToEdit.checkInDate).format('YYYY-MM-DD')
+        : '',
+      checkoutDate: (bookingToEdit.checkoutDate || bookingToEdit.checkOutDate)
+        ? dayjs(bookingToEdit.checkoutDate || bookingToEdit.checkOutDate).format('YYYY-MM-DD')
+        : '',
       bookingSource: bookingToEdit.bookingSource || 'Walk-in',
       amountGuestPaid: bookingToEdit.amountGuestPaid ?? 0,
       commissionAmount: bookingToEdit.commissionAmount ?? 0,


### PR DESCRIPTION
## Summary
- populate check-in and check-out fields when editing bookings
- add console log for debugging

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68603dcdb054832b94a46e2d431719a5