### PR TITLE
Add bank accounts CRUD and integrate with bookings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Listings from './pages/Listings';
 import Bookings from './pages/Bookings';
 import Reports from './pages/Reports';
 import Guests from './pages/Guests';
+import BankAccountsPage from './pages/BankAccountsPage';
 
 const App = () => {
   // const { loginWithRedirect, logout, isAuthenticated, user, isLoading } = useAuth0();
@@ -28,6 +29,7 @@ const App = () => {
         <Link to="/guests">Guests</Link>{' '}
         <Link to="/">Bookings</Link>{' '}
         <Link to="/Reports">Reports</Link>{' '}
+        <Link to="/bank-accounts">Bank Accounts</Link>{' '}
         {/* Navigation links */}
         {/**
         {isAuthenticated ? (
@@ -50,9 +52,10 @@ const App = () => {
           <Route path="/" element={<Bookings />} />
           <Route path="/listings" element={<Listings />} />
           <Route path="/guests" element={<Guests />} />
-          <Route path="/properties" element={<Properties />} />
-          <Route path="/reports" element={<Reports/>} />
-          {/* Add more routes as needed */}
+        <Route path="/properties" element={<Properties />} />
+        <Route path="/reports" element={<Reports/>} />
+        <Route path="/bank-accounts" element={<BankAccountsPage />} />
+        {/* Add more routes as needed */}
         </Routes>
         {/* ) : isAuthenticated ? (
           <p style={{ padding: '1rem', color: 'crimson' }}>

--- a/src/api/bankAccountsApi.js
+++ b/src/api/bankAccountsApi.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_BASE;
+
+export const getBankAccounts = async () => {
+  const res = await axios.get(`${API_BASE}/bankaccounts`);
+  return res.data;
+};
+
+export const createBankAccount = async (data) => {
+  const res = await axios.post(`${API_BASE}/bankaccounts`, data);
+  return res.data;
+};
+
+export const updateBankAccount = async (id, data) => {
+  const res = await axios.put(`${API_BASE}/bankaccounts/${id}`, data);
+  return res.data;
+};
+
+export const deleteBankAccount = async (id) => {
+  const res = await axios.delete(`${API_BASE}/bankaccounts/${id}`);
+  return res.data;
+};

--- a/src/api/bookingsApi.js
+++ b/src/api/bookingsApi.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_BASE;
+
+export const getBookings = async () => {
+  const res = await axios.get(`${API_BASE}/bookings`);
+  return res.data;
+};
+
+export const createBooking = async (data) => {
+  const res = await axios.post(`${API_BASE}/bookings`, data);
+  return res.data;
+};
+
+export const updateBooking = async (id, data) => {
+  const res = await axios.put(`${API_BASE}/bookings/${id}`, data);
+  return res.data;
+};
+
+export const deleteBooking = async (id) => {
+  const res = await axios.delete(`${API_BASE}/bookings/${id}`);
+  return res.data;
+};

--- a/src/components/BankAccountForm.jsx
+++ b/src/components/BankAccountForm.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Box, TextField } from '@mui/material';
+
+const BankAccountForm = ({ form, setForm }) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+    <TextField
+      label="Bank Name"
+      required
+      value={form.bankName}
+      onChange={e => setForm({ ...form, bankName: e.target.value })}
+    />
+    <TextField
+      label="Account Number"
+      required
+      value={form.accountNumber}
+      onChange={e => setForm({ ...form, accountNumber: e.target.value })}
+    />
+    <TextField
+      label="IFSC"
+      required
+      value={form.ifsc}
+      onChange={e => setForm({ ...form, ifsc: e.target.value })}
+    />
+    <TextField
+      label="Account Type"
+      required
+      value={form.accountType}
+      onChange={e => setForm({ ...form, accountType: e.target.value })}
+    />
+  </Box>
+);
+
+export default BankAccountForm;

--- a/src/pages/BankAccountsPage.jsx
+++ b/src/pages/BankAccountsPage.jsx
@@ -1,0 +1,206 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+  Paper,
+  Snackbar,
+  Alert
+} from '@mui/material';
+import {
+  getBankAccounts,
+  createBankAccount,
+  updateBankAccount,
+  deleteBankAccount
+} from '../api/bankAccountsApi';
+import BankAccountForm from '../components/BankAccountForm';
+
+const BankAccountsPage = () => {
+  const [accounts, setAccounts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ bankName: '', accountNumber: '', ifsc: '', accountType: '' });
+  const [editId, setEditId] = useState(null);
+  const [deleteItem, setDeleteItem] = useState(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await getBankAccounts();
+      setAccounts(data);
+    } catch (err) {
+      setError('Failed to fetch bank accounts.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handleOpen = (acc) => {
+    if (acc) {
+      setForm({
+        bankName: acc.bankName || '',
+        accountNumber: acc.accountNumber || '',
+        ifsc: acc.ifsc || '',
+        accountType: acc.accountType || ''
+      });
+      setEditId(acc.id);
+    } else {
+      setForm({ bankName: '', accountNumber: '', ifsc: '', accountType: '' });
+      setEditId(null);
+    }
+    setOpen(true);
+  };
+
+  const handleClose = () => setOpen(false);
+
+  const submit = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      if (editId) {
+        await updateBankAccount(editId, form);
+        setSuccess('Bank account updated');
+      } else {
+        await createBankAccount(form);
+        setSuccess('Bank account created');
+      }
+      handleClose();
+      fetchData();
+    } catch (err) {
+      setError('Failed to save bank account.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteItem) return;
+    setLoading(true);
+    setError('');
+    try {
+      await deleteBankAccount(deleteItem.id);
+      setSuccess('Bank account deleted');
+      fetchData();
+    } catch (err) {
+      setError('Failed to delete bank account.');
+    } finally {
+      setDeleteItem(null);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Button variant="contained" onClick={() => handleOpen()} sx={{ mb: 2 }}>
+        New Bank Account
+      </Button>
+
+      {loading && accounts.length === 0 ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Paper elevation={2}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Bank</TableCell>
+                <TableCell>Account Number</TableCell>
+                <TableCell>IFSC</TableCell>
+                <TableCell>Type</TableCell>
+                <TableCell>Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {accounts.map(acc => (
+                <TableRow key={acc.id} hover>
+                  <TableCell>{acc.bankName}</TableCell>
+                  <TableCell>{acc.accountNumber}</TableCell>
+                  <TableCell>{acc.ifsc}</TableCell>
+                  <TableCell>{acc.accountType}</TableCell>
+                  <TableCell>
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                      <Button size="small" variant="outlined" onClick={() => handleOpen(acc)} disabled={loading}>Edit</Button>
+                      <Button size="small" color="error" variant="outlined" onClick={() => setDeleteItem(acc)} disabled={loading}>Delete</Button>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {accounts.length === 0 && !loading && (
+                <TableRow>
+                  <TableCell colSpan={5} sx={{ textAlign: 'center', py: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No bank accounts found.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+        <DialogTitle>{editId ? 'Edit Bank Account' : 'New Bank Account'}</DialogTitle>
+        <DialogContent>
+          <BankAccountForm form={form} setForm={setForm} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} disabled={loading}>Cancel</Button>
+          <Button onClick={submit} variant="contained" disabled={loading}>
+            {editId ? 'Update' : 'Create'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteItem)} onClose={() => setDeleteItem(null)}>
+        <DialogTitle>Delete Bank Account</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete {deleteItem?.bankName}?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteItem(null)} disabled={loading}>Cancel</Button>
+          <Button color="error" onClick={confirmDelete} disabled={loading}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={Boolean(success)}
+        autoHideDuration={3000}
+        onClose={() => setSuccess('')}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setSuccess('')} severity="success" sx={{ width: '100%' }}>
+          {success}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default BankAccountsPage;

--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -12,6 +12,7 @@ const Bookings = () => {
   const [listings, setListings] = useState([]);
   const [bookings, setBookings] = useState([]);
   const [guests, setGuests] = useState([]);
+  const [bankAccounts, setBankAccounts] = useState([]);
   const [selectedGuestId, setSelectedGuestId] = useState('');
   const [guest, setGuest] = useState({ name: '', phone: '', email: '' });
   const [booking, setBooking] = useState({
@@ -24,6 +25,7 @@ const Bookings = () => {
     commissionAmount: 0,
     amountReceived: 0,
     notes: '',
+    bankAccountId: ''
   });
   const [guestsPlanned, setGuestsPlanned] = useState(2);
   const [guestsActual, setGuestsActual] = useState(2);
@@ -73,6 +75,7 @@ const Bookings = () => {
       setBookings(sorted);
     });
     axios.get(`${import.meta.env.VITE_API_BASE}/guests`).then(res => setGuests(res.data));
+    axios.get(`${import.meta.env.VITE_API_BASE}/bankaccounts`).then(res => setBankAccounts(res.data));
   }, []);
 
   useEffect(() => {
@@ -103,7 +106,8 @@ const Bookings = () => {
       amountGuestPaid: 0,
       commissionAmount: 0,
       amountReceived: 0,
-      notes: ''
+      notes: '',
+      bankAccountId: ''
     });
     setGuestsPlanned(2);
     setGuestsActual(2);
@@ -131,6 +135,7 @@ const Bookings = () => {
         ...booking,
         guestId,
         listingId: parseInt(booking.listingId),
+        bankAccountId: booking.bankAccountId ? parseInt(booking.bankAccountId) : null,
         amountGuestPaid: parseFloat(booking.amountGuestPaid),
         commissionAmount: parseFloat(booking.commissionAmount),
         amountReceived: parseFloat(booking.amountReceived),
@@ -180,7 +185,8 @@ const Bookings = () => {
       amountGuestPaid: bookingToEdit.amountGuestPaid ?? 0,
       commissionAmount: bookingToEdit.commissionAmount ?? 0,
       amountReceived: bookingToEdit.amountReceived ?? 0,
-      notes: bookingToEdit.notes || ''
+      notes: bookingToEdit.notes || '',
+      bankAccountId: bookingToEdit.bankAccountId ? bookingToEdit.bankAccountId.toString() : ''
     });
     setGuestsPlanned(bookingToEdit.guestsPlanned ?? 2);
     setGuestsActual(bookingToEdit.guestsActual ?? 2);
@@ -379,6 +385,23 @@ const Bookings = () => {
                   <MenuItem value="Atlas Website">Atlas Website</MenuItem>
                   <MenuItem value="Agent">Agent</MenuItem>
                   <MenuItem value="Others">Others</MenuItem>
+                </Select>
+              </FormControl>
+
+              {/* Bank Account */}
+              <FormControl>
+                <InputLabel>Bank Account</InputLabel>
+                <Select
+                  value={booking.bankAccountId}
+                  onChange={e => setBooking({ ...booking, bankAccountId: e.target.value })}
+                  label="Bank Account"
+                >
+                  <MenuItem value="">Select Account</MenuItem>
+                  {bankAccounts.map(acc => (
+                    <MenuItem key={acc.id} value={acc.id}>
+                      {`${acc.bankName} - ${acc.accountNumber}`}
+                    </MenuItem>
+                  ))}
                 </Select>
               </FormControl>
               {/* Gross Amount */}


### PR DESCRIPTION
## Summary
- create API helpers for bank accounts and bookings
- add BankAccountsPage for CRUD operations
- allow assigning a bank account on bookings
- expose new page and route in app navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860e371d63c832b98361a31edf18b13