### PR TITLE
Reorder reports listing

### DIFF
--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -16,6 +16,12 @@ const Reports = () => {
                 <EarningsReport />
             </section>
             <section style={{ marginBottom: '2rem' }}>
+                <SingleCalendarEarningsReport />
+            </section>
+            <section style={{ marginBottom: '2rem' }}>
+                <MultiCalendarEarningsReport />
+            </section>
+            <section style={{ marginBottom: '2rem' }}>
                 <DailyPayoutReport />
             </section>
             <section style={{ marginBottom: '2rem' }}>
@@ -24,12 +30,6 @@ const Reports = () => {
             <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <section style={{ marginBottom: '2rem' }}>
                     <CustomReportGenerator />
-                </section>
-                <section style={{ marginBottom: '2rem' }}>
-                    <SingleCalendarEarningsReport />
-                </section>
-                <section style={{ marginBottom: '2rem' }}>
-                    <MultiCalendarEarningsReport />
                 </section>
             </LocalizationProvider>
         </div>


### PR DESCRIPTION
## Summary
- reorder the sections on the Reports page so the new calendar reports appear immediately after the 12-Month On-Month Earnings Report

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68611d982194832b9e12b9d5bcfb3677