### PR TITLE
Add bank account earnings report

### DIFF
--- a/src/api/bankAccountsApi.js
+++ b/src/api/bankAccountsApi.js
@@ -21,3 +21,10 @@ export const deleteBankAccount = async (id) => {
   const res = await axios.delete(`${API_BASE}/bankaccounts/${id}`);
   return res.data;
 };
+
+export const getBankAccountEarnings = async () => {
+  const res = await axios.get(
+    `${API_BASE}/api/reports/bank-account-earnings`
+  );
+  return res.data;
+};

--- a/src/components/BankAccountEarningsReport.jsx
+++ b/src/components/BankAccountEarningsReport.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, CircularProgress, Paper } from '@mui/material';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { getBankAccountEarnings } from '../api/bankAccountsApi';
+
+const BankAccountEarningsReport = () => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await getBankAccountEarnings();
+        const arr = Array.isArray(res) ? res : [];
+        const normalized = arr.map((entry) => ({
+          label: `${entry.bankName} ${entry.accountNumber}`,
+          tooltip: `${entry.bankName} (${String(entry.accountNumber).slice(-4)})`,
+          amount: parseFloat(entry.amountReceived) || 0,
+        }));
+        setData(normalized);
+      } catch (err) {
+        console.error(err);
+        setError('Failed to load report');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return (
+    <Paper elevation={2} sx={{ p: 3, mt: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        🏦 Bank Account Earnings Report (FY 2025–26)
+      </Typography>
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Typography color="error">{error}</Typography>
+      ) : (
+        <Box sx={{ width: '100%', height: 400 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="label" />
+              <YAxis tickFormatter={(v) => `₹${v.toLocaleString('en-IN')}`} />
+              <Tooltip
+                formatter={(val) => `₹${Number(val).toLocaleString('en-IN')}`}
+                labelFormatter={(label, payload) => {
+                  const item = payload && payload[0] && payload[0].payload;
+                  return item ? item.tooltip : label;
+                }}
+              />
+              <Bar dataKey="amount" fill="#4caf50" />
+            </BarChart>
+          </ResponsiveContainer>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+export default BankAccountEarningsReport;

--- a/src/pages/BankAccountsPage.jsx
+++ b/src/pages/BankAccountsPage.jsx
@@ -24,6 +24,7 @@ import {
   deleteBankAccount
 } from '../api/bankAccountsApi';
 import BankAccountForm from '../components/BankAccountForm';
+import BankAccountEarningsReport from '../components/BankAccountEarningsReport';
 
 const BankAccountsPage = () => {
   const [accounts, setAccounts] = useState([]);
@@ -162,6 +163,8 @@ const BankAccountsPage = () => {
           </Table>
         </Paper>
       )}
+
+      <BankAccountEarningsReport />
 
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
         <DialogTitle>{editId ? 'Edit Bank Account' : 'New Bank Account'}</DialogTitle>


### PR DESCRIPTION
## Summary
- display bank account wise earnings chart on the Bank Accounts page
- fetch earnings data from `/api/reports/bank-account-earnings`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6888eac3753c832b941a594790cd4022