### PR TITLE
Add cell highlights and larger font in calendar earnings

### DIFF
--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -64,7 +64,17 @@ function SingleCalendarEarningsReport() {
   const dayPropGetter = (date) => {
     const key = format(date, 'yyyy-MM-dd');
     const amount = parseFloat(earnings[key]);
-    return amount > 0 ? { style: { backgroundColor: '#e6ffed' } } : {};
+    if (isNaN(amount) || amount <= 0) return {};
+
+    if (amount >= thresholds.top) {
+      return { style: { backgroundColor: '#add8e6' } };
+    }
+
+    if (amount <= thresholds.bottom) {
+      return { style: { backgroundColor: '#f8d7da' } };
+    }
+
+    return { style: { backgroundColor: '#e6ffed' } };
   };
 
   const components = {
@@ -78,7 +88,7 @@ function SingleCalendarEarningsReport() {
         return (
           <div style={{ textAlign: 'center' }}>
             <div>{label}</div>
-            <div style={{ fontSize: '0.75em' }}>
+            <div style={{ fontSize: '1.5em', fontWeight: 'bold' }}>
               <span className={highlightClass}>{display}</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- improve styling of single calendar earnings
- show revenue amounts with bigger bold font
- color the top 5% revenue days light blue and bottom 5% light red

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68898b205d5c832bb9b0651a477d3457