### PR TITLE
Update calendar earnings highlight logic

### DIFF
--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -5,7 +5,7 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { format, parse, startOfWeek, getDay } from 'date-fns';
 import axios from 'axios';
 import { enUS } from 'date-fns/locale';
-import { computeThresholds, getHighlightClass } from '../utils/percentile';
+import { computeThresholds, getHighlightStyle } from '../utils/percentile';
 
 const locales = { 'en-US': enUS };
 const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
@@ -63,15 +63,21 @@ function SingleCalendarEarningsReport() {
 
   const dayPropGetter = (date) => {
     const key = format(date, 'yyyy-MM-dd');
-    const amount = parseFloat(earnings[key]);
+    const entry = earnings[key];
+    const amount = entry && typeof entry === 'object' ? parseFloat(entry.amount) : parseFloat(entry);
     if (isNaN(amount) || amount <= 0) return {};
 
-    if (amount >= thresholds.top) {
-      return { style: { backgroundColor: '#add8e6' } };
-    }
-
-    if (amount <= thresholds.bottom) {
-      return { style: { backgroundColor: '#f8d7da' } };
+    if (entry && typeof entry === 'object') {
+      const source = String(entry.source || '').toLowerCase();
+      if (source === 'airbnb') {
+        return { style: { backgroundColor: '#FD5C63' } };
+      }
+      if (source === 'booking.com') {
+        return { style: { backgroundColor: '#499FDD' } };
+      }
+      if (source === 'agoda') {
+        return { style: { backgroundColor: '#FDB812' } };
+      }
     }
 
     return { style: { backgroundColor: '#e6ffed' } };
@@ -81,15 +87,22 @@ function SingleCalendarEarningsReport() {
     month: {
       dateHeader: ({ label, date }) => {
         const key = format(date, 'yyyy-MM-dd');
-        const amount = parseFloat(earnings[key]);
+        const entry = earnings[key];
+        const amount = entry && typeof entry === 'object' ? parseFloat(entry.amount) : parseFloat(entry);
         const price = isNaN(amount) ? 0 : amount;
         const display = `₹${price.toLocaleString('en-IN')}`;
-        const highlightClass = getHighlightClass(price, thresholds);
+        const highlightStyle = getHighlightStyle(price, thresholds);
+        const source = entry && typeof entry === 'object' ? entry.source : null;
         return (
           <div style={{ textAlign: 'center' }}>
             <div>{label}</div>
+            {source && (
+              <div style={{ fontSize: '0.75em', textTransform: 'capitalize' }}>
+                {source}
+              </div>
+            )}
             <div style={{ fontSize: '1.5em', fontWeight: 'bold' }}>
-              <span className={highlightClass}>{display}</span>
+              <span style={highlightStyle}>{display}</span>
             </div>
           </div>
         );
@@ -160,7 +173,10 @@ function SingleCalendarEarningsReport() {
         <Typography sx={{ mt: 2, fontWeight: 'bold' }}>
           Total:{' '}
           {Object.values(earnings)
-            .reduce((sum, val) => sum + (parseFloat(val) || 0), 0)
+            .reduce((sum, val) => {
+              const amt = val && typeof val === 'object' ? parseFloat(val.amount) : parseFloat(val);
+              return sum + (isNaN(amt) ? 0 : amt);
+            }, 0)
             .toLocaleString('en-IN', {
               style: 'currency',
               currency: 'INR',

--- a/src/utils/percentile.js
+++ b/src/utils/percentile.js
@@ -6,19 +6,25 @@ export function percentile(arr, p) {
 }
 
 export function computeThresholds(earnings) {
-  const values = Object.values(earnings).map(v => parseFloat(v)).filter(v => v > 0);
+  const values = Object.values(earnings)
+    .map((v) => {
+      if (v && typeof v === 'object') {
+        return parseFloat(v.amount);
+      }
+      return parseFloat(v);
+    })
+    .filter((v) => !isNaN(v) && v > 0);
   const top = percentile(values, 95);
   const bottom = percentile(values, 5);
   return { top, bottom };
 }
 
-export function getHighlightClass(price, thresholds) {
-  const classes = ['text-lg', 'font-bold'];
+export function getHighlightStyle(price, thresholds) {
   if (price >= thresholds.top) {
-    classes.push('bg-blue-100', 'text-blue-900', 'rounded', 'px-1');
+    return { color: '#add8e6' };
   }
   if (price <= thresholds.bottom) {
-    classes.push('bg-red-100', 'text-red-900', 'rounded', 'px-1');
+    return { color: '#f8d7da' };
   }
-  return classes.join(' ');
+  return {};
 }

--- a/src/utils/percentile.test.js
+++ b/src/utils/percentile.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { percentile, computeThresholds, getHighlightClass } from './percentile';
+import { percentile, computeThresholds, getHighlightStyle } from './percentile';
 
 describe('percentile', () => {
   it('calculates percentile correctly', () => {
@@ -21,13 +21,25 @@ describe('computeThresholds', () => {
     expect(result.top).toBe(100);
     expect(result.bottom).toBe(10);
   });
+
+  it('works with earnings objects containing amount property', () => {
+    const earnings = {
+      '2024-01-01': { amount: 10 },
+      '2024-01-02': { amount: 0 },
+      '2024-01-03': { amount: 100 },
+      '2024-01-04': { amount: 50 }
+    };
+    const result = computeThresholds(earnings);
+    expect(result.top).toBe(100);
+    expect(result.bottom).toBe(10);
+  });
 });
 
-describe('getHighlightClass', () => {
-  it('returns classes based on thresholds', () => {
-    const cls = getHighlightClass(100, { top: 80, bottom: 20 });
-    expect(cls).toContain('bg-blue-100');
-    const cls2 = getHighlightClass(10, { top: 80, bottom: 20 });
-    expect(cls2).toContain('bg-red-100');
+describe('getHighlightStyle', () => {
+  it('returns style based on thresholds', () => {
+    const style = getHighlightStyle(100, { top: 80, bottom: 20 });
+    expect(style).toEqual({ color: '#add8e6' });
+    const style2 = getHighlightStyle(10, { top: 80, bottom: 20 });
+    expect(style2).toEqual({ color: '#f8d7da' });
   });
 });


### PR DESCRIPTION
## Summary
- indicate booking source with custom background colors
- change highlight logic to apply light blue/red text color
- support new earnings object shape in percentile helpers
- update tests for new highlight behaviour

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68898eed3c4c832b8c72069b9d5dd24c