### PR TITLE
Update highlight colors for revenue thresholds

### DIFF
--- a/src/utils/percentile.js
+++ b/src/utils/percentile.js
@@ -21,10 +21,10 @@ export function computeThresholds(earnings) {
 
 export function getHighlightStyle(price, thresholds) {
   if (price >= thresholds.top) {
-    return { color: '#add8e6' };
+    return { color: 'blue' };
   }
   if (price <= thresholds.bottom) {
-    return { color: '#f8d7da' };
+    return { color: 'red' };
   }
   return {};
 }

--- a/src/utils/percentile.test.js
+++ b/src/utils/percentile.test.js
@@ -38,8 +38,8 @@ describe('computeThresholds', () => {
 describe('getHighlightStyle', () => {
   it('returns style based on thresholds', () => {
     const style = getHighlightStyle(100, { top: 80, bottom: 20 });
-    expect(style).toEqual({ color: '#add8e6' });
+    expect(style).toEqual({ color: 'blue' });
     const style2 = getHighlightStyle(10, { top: 80, bottom: 20 });
-    expect(style2).toEqual({ color: '#f8d7da' });
+    expect(style2).toEqual({ color: 'red' });
   });
 });


### PR DESCRIPTION
## Summary
- update blue/red threshold colors in percentile utils
- update tests for new colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68899164147c832b823047af5432343e