### PR TITLE
Update revenue highlight rules

### DIFF
--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -91,7 +91,8 @@ function SingleCalendarEarningsReport() {
         const amount = entry && typeof entry === 'object' ? parseFloat(entry.amount) : parseFloat(entry);
         const price = isNaN(amount) ? 0 : amount;
         const display = `₹${price.toLocaleString('en-IN')}`;
-        const highlightStyle = getHighlightStyle(price, thresholds);
+        const sameMonth = format(date, 'yyyy-MM') === format(currentDate, 'yyyy-MM');
+        const highlightStyle = getHighlightStyle(price, thresholds, sameMonth);
         const source = entry && typeof entry === 'object' ? entry.source : null;
         return (
           <div style={{ textAlign: 'center' }}>

--- a/src/utils/percentile.js
+++ b/src/utils/percentile.js
@@ -19,12 +19,12 @@ export function computeThresholds(earnings) {
   return { top, bottom };
 }
 
-export function getHighlightStyle(price, thresholds) {
+export function getHighlightStyle(price, thresholds, isCurrentMonth = true) {
   if (price >= thresholds.top) {
-    return { color: '#add8e6' };
+    return { color: 'blue' };
   }
-  if (price <= thresholds.bottom) {
-    return { color: '#f8d7da' };
+  if (price <= thresholds.bottom && isCurrentMonth) {
+    return { color: 'red' };
   }
   return {};
 }

--- a/src/utils/percentile.test.js
+++ b/src/utils/percentile.test.js
@@ -38,8 +38,13 @@ describe('computeThresholds', () => {
 describe('getHighlightStyle', () => {
   it('returns style based on thresholds', () => {
     const style = getHighlightStyle(100, { top: 80, bottom: 20 });
-    expect(style).toEqual({ color: '#add8e6' });
-    const style2 = getHighlightStyle(10, { top: 80, bottom: 20 });
-    expect(style2).toEqual({ color: '#f8d7da' });
+    expect(style).toEqual({ color: 'blue' });
+    const style2 = getHighlightStyle(10, { top: 80, bottom: 20 }, true);
+    expect(style2).toEqual({ color: 'red' });
+  });
+
+  it('ignores bottom highlight for other months', () => {
+    const style = getHighlightStyle(10, { top: 80, bottom: 20 }, false);
+    expect(style).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- only highlight low earnings in red when the day belongs to the displayed month
- pass new flag from the SingleCalendar view
- cover the new behavior in percentile tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68899164147c832b823047af5432343e