### PR TITLE
Handle array calendar earnings data

### DIFF
--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -49,7 +49,23 @@ function SingleCalendarEarningsReport() {
         params: { listingId: selectedListingId, month },
       })
       .then((res) => {
-        const data = res.data && typeof res.data === 'object' ? res.data : {};
+        let data = res.data;
+        if (Array.isArray(data)) {
+          const map = {};
+          data.forEach((entry) => {
+            const date = entry && entry.date;
+            if (date) {
+              map[date] = {
+                amount: parseFloat(entry.amount) || 0,
+                source: entry.source || null,
+              };
+            }
+          });
+          data = map;
+        }
+
+        if (!data || typeof data !== 'object') data = {};
+
         setEarnings(data);
         setThresholds(computeThresholds(data));
       })


### PR DESCRIPTION
## Summary
- handle `/reports/calendar-earnings` responses that return arrays of daily data
- convert the array into the keyed object expected by `SingleCalendarEarningsReport`
- keep highlighting logic to show Airbnb, Booking.com and Agoda with distinct background colors

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6889a49d57ec832b92488b19a1178d0e