### PR TITLE
Remove gross amount usage in admin portal

### DIFF
--- a/src/components/EarningsReport.jsx
+++ b/src/components/EarningsReport.jsx
@@ -20,7 +20,6 @@ function buildEmptyMonths() {
     const d = dayjs().subtract(i, 'month');
     months[d.format('YYYY-MM')] = {
       month: d.format('MMM'),
-      totalGross: 0,
       totalFees: 0,
       totalNet: 0,
     };
@@ -41,7 +40,6 @@ function EarningsReport() {
         const normalized = Array.isArray(data)
           ? data.map((entry) => ({
               month: dayjs(entry.month).format('MMM'),
-              totalGross: entry.totalGross,
               totalFees: entry.totalFees,
               totalNet: entry.totalNet,
             }))
@@ -57,9 +55,10 @@ function EarningsReport() {
           res.data.forEach((b) => {
             const key = dayjs(b.paymentDate || b.createdAt).format('YYYY-MM');
             if (months[key]) {
-              const amt = parseFloat(b.amountReceived) || 0;
-              months[key].totalGross += amt;
-              months[key].totalNet += amt;
+              const net = parseFloat(b.amountReceived) || 0;
+              const fees = parseFloat(b.commissionAmount) || 0;
+              months[key].totalNet += net;
+              months[key].totalFees += fees;
             }
           });
           const aggregated = Object.values(months);
@@ -143,25 +142,25 @@ function EarningsReport() {
               <thead>
                 <tr style={{ textAlign: 'left', borderBottom: '1px solid #ddd', fontWeight: 600 }}>
                   <th style={{ padding: '0.5rem 1rem 0.5rem 0' }}>Month</th>
-                  <th style={{ padding: '0.5rem 1rem', textAlign: 'right' }}>Total Gross</th>
+                  <th style={{ padding: '0.5rem 1rem', textAlign: 'right' }}>Total</th>
                   <th style={{ padding: '0.5rem 1rem', textAlign: 'right' }}>Total Fees</th>
                   <th style={{ padding: '0.5rem 1rem', textAlign: 'right' }}>Total Net</th>
                 </tr>
               </thead>
               <tbody>
                 {monthlyData
-                  .filter((row) => showZeroMonths || row.totalGross > 0)
+                  .filter((row) => showZeroMonths || (row.totalNet + row.totalFees) > 0)
                   .map((row, idx) => (
                     <tr
                       key={row.month}
                       style={{
                         backgroundColor: idx % 2 === 0 ? '#f9fafb' : 'transparent',
-                        opacity: row.totalGross === 0 ? 0.5 : 1,
+                        opacity: (row.totalNet + row.totalFees) === 0 ? 0.5 : 1,
                       }}
                     >
                       <td style={{ padding: '0.5rem 1rem 0.5rem 0' }}>{row.month}</td>
                       <td style={{ padding: '0.5rem 1rem', textAlign: 'right' }}>
-                        ₹{row.totalGross.toLocaleString('en-IN', { minimumFractionDigits: 2 })}
+                        ₹{(row.totalNet + row.totalFees).toLocaleString('en-IN', { minimumFractionDigits: 2 })}
                       </td>
                       <td style={{ padding: '0.5rem 1rem', textAlign: 'right' }}>
                         ₹{row.totalFees.toLocaleString('en-IN', { minimumFractionDigits: 2 })}

--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -28,7 +28,6 @@ const Bookings = () => {
     checkinDate: '',
     checkoutDate: '',
     bookingSource: 'Walk-in',
-    amountGuestPaid: 0,
     commissionAmount: 0,
     amountReceived: 0,
     notes: '',
@@ -154,7 +153,6 @@ const Bookings = () => {
       checkoutDate: '',
 
       bookingSource: 'Walk-in',
-      amountGuestPaid: 0,
       commissionAmount: 0,
       amountReceived: 0,
       notes: '',
@@ -240,7 +238,6 @@ const Bookings = () => {
         ? dayjs(bookingToEdit.checkoutDate || bookingToEdit.checkOutDate).format('YYYY-MM-DD')
         : '',
       bookingSource: bookingToEdit.bookingSource || 'Walk-in',
-      amountGuestPaid: bookingToEdit.amountGuestPaid ?? 0,
       commissionAmount: bookingToEdit.commissionAmount ?? 0,
       amountReceived: bookingToEdit.amountReceived ?? 0,
       notes: bookingToEdit.notes || '',
@@ -487,19 +484,6 @@ const Bookings = () => {
                   ))}
                 </Select>
               </FormControl>
-              {/* Gross Amount */}
-              <TextField
-                label="Gross Amount"
-                type="number"
-                placeholder="Gross Amount"
-                value={booking.amountGuestPaid}
-                onChange={e => setBooking({ ...booking, amountGuestPaid: e.target.value })}
-                inputProps={{
-                  min: 0,
-                  step: "0.01"
-                }}
-              />
-
               {/* Commission Amount */}
               <TextField
                 label="Commission Amount"
@@ -525,6 +509,14 @@ const Bookings = () => {
                   step: "0.01"
                 }}
               />
+
+              {/* Total Amount (Net + Commission) */}
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                Total: ₹{(
+                  Number(booking.amountReceived || 0) +
+                  Number(booking.commissionAmount || 0)
+                ).toFixed(2)}
+              </Typography>
 
               {/* Notes */}
               <TextField
@@ -708,7 +700,7 @@ const Bookings = () => {
               <TableCell>Payment</TableCell>
               <TableCell>Guests</TableCell>
               <TableCell>Extra Charge (₹)</TableCell>
-              <TableCell>Gross (₹)</TableCell>
+              <TableCell>Total (₹)</TableCell>
               <TableCell>Commission (₹)</TableCell>
               <TableCell>Net (₹)</TableCell>
               <TableCell>Bank Account</TableCell>
@@ -718,7 +710,6 @@ const Bookings = () => {
           </TableHead>
           <TableBody>
             {paginatedBookings.map(row => {
-              console.log(row); // check for amountGuestPaid and commissionAmount
               const guestObj = guests.find(g => g.id === row.guestId) || {};
               const listingObj = listings.find(l => l.id === row.listingId) || {};
               const bankAccountObj =
@@ -730,6 +721,8 @@ const Bookings = () => {
               const prefix = bankName.slice(0, 4).toUpperCase();
               const suffix = accountNumber.slice(-4);
               const formattedBank = `${prefix}-${suffix}`;
+              const totalAmount =
+                Number(row.amountReceived || 0) + Number(row.commissionAmount || 0);
               return (
                 <TableRow key={row.id}>
                   <TableCell>{listingObj.name || row.listingId}</TableCell>
@@ -743,7 +736,7 @@ const Bookings = () => {
                   <TableCell>{row.paymentStatus}</TableCell>
                   <TableCell>{row.guestsPlanned} → {row.guestsActual}</TableCell>
                   <TableCell>₹{row.extraGuestCharge?.toLocaleString("en-IN")}</TableCell>
-                  <TableCell>₹{row.amountGuestPaid?.toLocaleString("en-IN", { minimumFractionDigits: 2 })}</TableCell>
+                  <TableCell>₹{totalAmount.toLocaleString("en-IN", { minimumFractionDigits: 2 })}</TableCell>
                   <TableCell>₹{row.commissionAmount?.toLocaleString("en-IN", { minimumFractionDigits: 2 })}</TableCell>
                   <TableCell>₹{row.amountReceived?.toLocaleString("en-IN")}</TableCell>
                   <TableCell>{formattedBank}</TableCell>

--- a/src/utils/buildBookingPayload.js
+++ b/src/utils/buildBookingPayload.js
@@ -18,7 +18,6 @@ export function buildBookingPayload({
     listingId: Number(listingId),
     notes: booking.notes?.trim() || '-',
     bankAccountId: booking.bankAccountId ? parseInt(booking.bankAccountId) : null,
-    amountGuestPaid: parseFloat(booking.amountGuestPaid),
     commissionAmount: parseFloat(booking.commissionAmount),
     amountReceived: parseFloat(booking.amountReceived),
     guestsPlanned,

--- a/src/utils/buildBookingPayload.test.js
+++ b/src/utils/buildBookingPayload.test.js
@@ -9,7 +9,6 @@ describe('buildBookingPayload', () => {
       checkinDate: '2024-01-01',
       checkoutDate: '2024-01-02',
       bookingSource: 'Walk-in',
-      amountGuestPaid: '100',
       commissionAmount: '10',
       amountReceived: '90',
       notes: '',


### PR DESCRIPTION
## Summary
- remove gross amount field from booking form and compute totals from net + commission
- drop gross column from bookings list and reports
- adjust booking payload and report generation to rely on net amount and commission

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688e62b5e0a0832b8d7b200d9e4a89ad