### PR TITLE
feat: display booking details on calendar tooltips

### DIFF
--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -195,6 +195,7 @@ function SingleCalendarEarningsReport() {
                     textOverflow: 'ellipsis',
                     lineHeight: 1.1,
                   }}
+                  title={`Booking #${e.bookingId}${e.guestName ? ` • ${e.guestName}` : ''} • ₹${Number(e.amount).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
                 >
                   {e.source}: ₹
                   {Number(e.amount).toLocaleString(undefined, { maximumFractionDigits: 2 })}


### PR DESCRIPTION
## Summary
- show booking ID and guest name in calendar earnings tooltips for easier debugging

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688fcc087bd8832b89a02d9066e3617c