### PR TITLE
feat: show booking details in calendar tooltips

### DIFF
--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -263,23 +263,30 @@ function SingleCalendarEarningsReport() {
                   {format(date, 'd')}
                 </div>
                 <div style={{ flex: 1, overflowY: 'auto', marginTop: 4 }}>
-                  {(data?.earnings || []).map((e, i) => (
-                    <div
-                      key={i}
-                      style={{
-                        fontSize: 11,
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      }}
-                      title={`Booking #${e.bookingId}${e.guestName ? ` • ${e.guestName}` : ''}`}
-                    >
-                      {e.source}: ₹
-                      {Number(e.amount).toLocaleString(undefined, {
-                        maximumFractionDigits: 2,
-                      })}
-                    </div>
-                  ))}
+                  {(data?.earnings || []).map((e, i) => {
+                    const amount = Number(e.amount).toLocaleString(undefined, {
+                      maximumFractionDigits: 2,
+                    });
+                    const tooltip = [
+                      `Check-in: ${format(new Date(e.checkinDate), 'dd MMM')}`,
+                      `Guest: ${e.guestName}`,
+                      `Amount: ₹${amount}`,
+                    ].join(' | ');
+                    return (
+                      <div
+                        key={i}
+                        style={{
+                          fontSize: 11,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                        title={tooltip}
+                      >
+                        {e.source}: ₹{amount}
+                      </div>
+                    );
+                  })}
                 </div>
                 {data?.total > 0 && (
                   <div


### PR DESCRIPTION
## Summary
- add rich hover tooltips showing check-in, guest name and amount

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688fd37aa730832bbb191d735b5c87ad