### PR TITLE
feat: make Auth0 audience optional

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ VITE_API_BASE=https://atlas-homes-api-gxdqfjc2btc0atbv.centralus-01.azurewebsite
 # Auth0 configuration
 VITE_AUTH0_DOMAIN=atlashomestays.us.auth0.com
 VITE_AUTH0_CLIENT_ID=d70OGzWag10f4viX8DI1SxOXAj6aDsvX
-VITE_AUTH0_AUDIENCE=https://atlas-api
+VITE_AUTH0_AUDIENCE=
 VITE_ALLOWED_EMAIL=atlashomeskphb@gmail.com
 
 # Set to true to bypass Auth0 locally

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ VITE_API_BASE=http://localhost:5000
 # Auth0 configuration
 VITE_AUTH0_DOMAIN=atlashomestays.us.auth0.com
 VITE_AUTH0_CLIENT_ID=d70OGzWag10f4viX8DI1SxOXAj6aDsvX
-VITE_AUTH0_AUDIENCE=https://atlas-api
+VITE_AUTH0_AUDIENCE=
 VITE_ALLOWED_EMAIL=atlashomeskphb@gmail.com
 
 # Set to true to bypass Auth0 locally

--- a/.env.local
+++ b/.env.local
@@ -2,7 +2,7 @@ VITE_API_BASE=https://localhost:7018
 
 VITE_AUTH0_DOMAIN=atlashomestays.us.auth0.com
 VITE_AUTH0_CLIENT_ID=d70OGzWag10f4viX8DI1SxOXAj6aDsvX
-VITE_AUTH0_AUDIENCE=https://atlas-api
+VITE_AUTH0_AUDIENCE=
 VITE_ALLOWED_EMAIL=atlashomeskphb@gmail.com
 # Set to true to bypass Auth0 locally
 VITE_AUTH_BYPASS=true

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -2,14 +2,15 @@ import { Auth0Provider } from '@auth0/auth0-react';
 import { AUTH0 } from './config';
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const audience = AUTH0.audience;
   return (
     <Auth0Provider
       domain={AUTH0.domain}
       clientId={AUTH0.clientId}
       authorizationParams={{
-        audience: AUTH0.audience,
         scope: 'openid profile email',
         redirect_uri: window.location.origin + '/auth/callback',
+        ...(audience ? { audience } : {}),
       }}
       onRedirectCallback={({ appState }) =>
         window.history.replaceState({}, document.title, appState?.returnTo || window.location.pathname)

--- a/src/auth/useApiClient.ts
+++ b/src/auth/useApiClient.ts
@@ -8,14 +8,15 @@ const api = axios.create({
 
 export function useApiClient() {
   const { getAccessTokenSilently } = useAtlasAuth();
+  const audience = import.meta.env.VITE_AUTH0_AUDIENCE;
+
   api.interceptors.request.use(async (config) => {
-    if (!BYPASS) {
-      const token = await getAccessTokenSilently({
-        authorizationParams: { audience: import.meta.env.VITE_AUTH0_AUDIENCE }
-      });
+    if (!BYPASS && audience) {
+      const token = await getAccessTokenSilently({ authorizationParams: { audience } });
       if (token) config.headers = { ...config.headers, Authorization: `Bearer ${token}` };
     }
     return config;
   });
+
   return api;
 }


### PR DESCRIPTION
## Summary
- remove Auth0 audience from default environment files
- send audience to Auth0 only when set
- avoid requesting access tokens when audience is absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a591563c832ba676aecc838fc581