### PR TITLE
Add unified auth bypass and ProtectedRoute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
-import { useAuth0 } from "@auth0/auth0-react";
+import { Link, Navigate, Route, Routes } from "react-router-dom";
 import BookingsPage from "./pages/Bookings";
 import CallbackPage from "./pages/AuthCallback";
 import Listings from "./pages/Listings";
@@ -7,29 +6,11 @@ import Properties from "./pages/Properties";
 import Reports from "./pages/Reports";
 import Guests from "./pages/Guests";
 import BankAccountsPage from "./pages/BankAccountsPage";
-import { useAuthMaybeBypass } from "./auth/authBypass";
-
-function Protected({ children }: { children: JSX.Element }) {
-  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
-  const { bypassUser } = useAuthMaybeBypass();
-  const location = useLocation();
-
-  const effectiveIsAuthenticated = !!bypassUser || isAuthenticated;
-
-  if (isLoading) return <div>Loading…</div>;
-  if (!effectiveIsAuthenticated) {
-    void loginWithRedirect({ appState: { returnTo: location.pathname + location.search } });
-    return <div>Loading…</div>;
-  }
-  return children;
-}
+import ProtectedRoute from "./auth/ProtectedRoute";
+import { useEffectiveAuth } from "./auth/useEffectiveAuth";
 
 export default function AppRoutes() {
-  const { isAuthenticated, user, logout } = useAuth0();
-  const { bypassUser } = useAuthMaybeBypass();
-
-  const effectiveUser = bypassUser ?? (isAuthenticated ? user : null);
-  const effectiveIsAuthenticated = !!effectiveUser;
+  const { effectiveIsAuthenticated, effectiveUser, logout, bypassEnabled } = useEffectiveAuth();
 
   return (
     <>
@@ -40,7 +21,7 @@ export default function AppRoutes() {
         <Link to="/guests">Guests</Link>{" "}
         <Link to="/bookings">Bookings</Link>{" "}
         <Link to="/reports">Reports</Link>{" "}
-        {bypassUser && (
+        {bypassEnabled && (
           <span style={{ marginLeft: 10, fontSize: "0.75rem", padding: "2px 4px", borderRadius: 4, backgroundColor: "#FEF08A" }}>
             AUTH BYPASS (LOCAL)
           </span>
@@ -58,54 +39,12 @@ export default function AppRoutes() {
       <Routes>
         <Route path="/" element={<Navigate to="/bookings" replace />} />
         <Route path="/auth/callback" element={<CallbackPage />} />
-        <Route
-          path="/bookings"
-          element={
-            <Protected>
-              <BookingsPage />
-            </Protected>
-          }
-        />
-        <Route
-          path="/listings"
-          element={
-            <Protected>
-              <Listings />
-            </Protected>
-          }
-        />
-        <Route
-          path="/guests"
-          element={
-            <Protected>
-              <Guests />
-            </Protected>
-          }
-        />
-        <Route
-          path="/properties"
-          element={
-            <Protected>
-              <Properties />
-            </Protected>
-          }
-        />
-        <Route
-          path="/reports"
-          element={
-            <Protected>
-              <Reports />
-            </Protected>
-          }
-        />
-        <Route
-          path="/bank-accounts"
-          element={
-            <Protected>
-              <BankAccountsPage />
-            </Protected>
-          }
-        />
+        <Route path="/bookings" element={<ProtectedRoute><BookingsPage /></ProtectedRoute>} />
+        <Route path="/listings" element={<ProtectedRoute><Listings /></ProtectedRoute>} />
+        <Route path="/guests" element={<ProtectedRoute><Guests /></ProtectedRoute>} />
+        <Route path="/properties" element={<ProtectedRoute><Properties /></ProtectedRoute>} />
+        <Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} />
+        <Route path="/bank-accounts" element={<ProtectedRoute><BankAccountsPage /></ProtectedRoute>} />
         {/* other protected routes here */}
         <Route path="*" element={<Navigate to="/bookings" replace />} />
       </Routes>

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { useAuthMaybeBypass } from '../auth/authBypass';
+import { useEffectiveAuth } from '../auth/useEffectiveAuth';
 
 const http = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:7071/api',
@@ -9,11 +9,11 @@ const http = axios.create({
 
 export function useHttp() {
   const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
-  const { bypassUser } = useAuthMaybeBypass();
+  const { bypassEnabled } = useEffectiveAuth();
   const audience = import.meta.env.VITE_AUTH0_AUDIENCE;
 
   useEffect(() => {
-    if (bypassUser) return;
+    if (bypassEnabled) return;
 
     const reqInterceptor = http.interceptors.request.use(async (config) => {
       if (audience) {
@@ -43,7 +43,7 @@ export function useHttp() {
       http.interceptors.request.eject(reqInterceptor);
       http.interceptors.response.eject(resInterceptor);
     };
-  }, [getAccessTokenSilently, loginWithRedirect, audience, bypassUser]);
+  }, [getAccessTokenSilently, loginWithRedirect, audience, bypassEnabled]);
 
   return http;
 }

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useEffectiveAuth } from './useEffectiveAuth';
+
+export default function ProtectedRoute({ children }: { children: JSX.Element }) {
+  const { isLoading, effectiveIsAuthenticated, loginWithRedirect, bypassEnabled } = useEffectiveAuth();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isLoading && !effectiveIsAuthenticated && !bypassEnabled) {
+      void loginWithRedirect({ appState: { returnTo: location.pathname + location.search } });
+    }
+  }, [isLoading, effectiveIsAuthenticated, bypassEnabled, loginWithRedirect, location]);
+
+  if (isLoading) return null;
+
+  // In dev with bypass on but not yet loaded, just show nothing briefly;
+  // once /auth-bypass.json loads, user becomes authenticated.
+  if (!effectiveIsAuthenticated && bypassEnabled) return null;
+
+  // In prod, after redirectWithLogin call we render nothing here.
+  if (!effectiveIsAuthenticated) return null;
+
+  return children;
+}

--- a/src/auth/useApiClient.ts
+++ b/src/auth/useApiClient.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useAuth0 } from '@auth0/auth0-react';
-import { useAuthMaybeBypass } from './authBypass';
+import { useEffectiveAuth } from './useEffectiveAuth';
 
 const api = axios.create({
   baseURL: 'https://atlas-homes-api-gxdqfjc2btc0atbv.centralus-01.azurewebsites.net'
@@ -8,11 +8,11 @@ const api = axios.create({
 
 export function useApiClient() {
   const { getAccessTokenSilently } = useAuth0();
-  const { bypassUser } = useAuthMaybeBypass();
+  const { bypassEnabled } = useEffectiveAuth();
   const audience = import.meta.env.VITE_AUTH0_AUDIENCE;
 
   api.interceptors.request.use(async (config) => {
-    if (!bypassUser && audience) {
+    if (!bypassEnabled && audience) {
       const token = await getAccessTokenSilently({ authorizationParams: { audience } });
       if (token) config.headers = { ...config.headers, Authorization: `Bearer ${token}` };
     }

--- a/src/auth/useEffectiveAuth.ts
+++ b/src/auth/useEffectiveAuth.ts
@@ -1,0 +1,17 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { useAuthMaybeBypass } from './authBypass';
+
+if (import.meta.env.DEV) {
+  console.log('Bypass enabled:', import.meta.env.VITE_AUTH_BYPASS === 'true');
+}
+
+export function useEffectiveAuth() {
+  const { isAuthenticated, user, isLoading, loginWithRedirect, logout } = useAuth0();
+  const { bypassUser } = useAuthMaybeBypass();
+
+  const bypassEnabled = import.meta.env.DEV && import.meta.env.VITE_AUTH_BYPASS === 'true';
+  const effectiveUser = (bypassEnabled && bypassUser) ? bypassUser : (isAuthenticated ? user : null);
+  const effectiveIsAuthenticated = !!effectiveUser;
+
+  return { isLoading, effectiveIsAuthenticated, effectiveUser, loginWithRedirect, logout, bypassEnabled };
+}


### PR DESCRIPTION
## Summary
- add `useEffectiveAuth` hook merging Auth0 user and bypass user
- introduce `ProtectedRoute` and update routing to use it
- skip auth token handling when bypass enabled in HTTP utilities

## Testing
- `npm test -- --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_68b5dbbc94e8832bbe099e290988093d