### PR TITLE
Allow multiple admin emails via env and add error boundary

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -12,3 +12,4 @@ VITE_GUEST_SEARCH_MODE=local
 
 # Auth0 configuration
 VITE_AUTH_BYPASS=false
+VITE_ALLOWED_EMAILS=atlashomeskphb@gmail.com,sreekar.atla@gmail.com

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useEffectiveAuth } from './useEffectiveAuth';
+import RequireAuth from './RequireAuth';
 
 export default function ProtectedRoute({ children }: { children: JSX.Element }) {
-  const { isLoading, effectiveIsAuthenticated, loginWithRedirect, bypassEnabled } = useEffectiveAuth();
+  const { isLoading, effectiveIsAuthenticated, effectiveUser, loginWithRedirect, bypassEnabled } = useEffectiveAuth();
   const location = useLocation();
 
   useEffect(() => {
@@ -21,5 +22,5 @@ export default function ProtectedRoute({ children }: { children: JSX.Element }) 
   // In prod, after redirectWithLogin call we render nothing here.
   if (!effectiveIsAuthenticated) return null;
 
-  return children;
+  return <RequireAuth user={effectiveUser}>{children}</RequireAuth>;
 }

--- a/src/auth/RequireAuth.test.ts
+++ b/src/auth/RequireAuth.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { isEmailAllowed } from "./RequireAuth";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isEmailAllowed", () => {
+  it("returns true for allowed email", () => {
+    vi.stubEnv("VITE_ALLOWED_EMAILS", '["user@example.com"]');
+    expect(isEmailAllowed("user@example.com")).toBe(true);
+  });
+
+  it("returns false for disallowed email", () => {
+    vi.stubEnv("VITE_ALLOWED_EMAILS", '["user@example.com"]');
+    expect(isEmailAllowed("other@example.com")).toBe(false);
+  });
+});

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { getAllowedEmails } from "../utils/env";
+
+export function isEmailAllowed(email?: string | null): boolean {
+  if (!email) return false;
+  const allowed = getAllowedEmails();
+  if (!Array.isArray(allowed) || allowed.length === 0) return false;
+  return allowed.some((x) => x.toLowerCase() === email.toLowerCase());
+}
+
+export default function RequireAuth({ user, children }: { user: any; children: React.ReactNode }) {
+  const email = user?.email ?? null;
+  if (!isEmailAllowed(email)) {
+    return <div style={{ padding: 24 }}>Access restricted. Please contact admin.</div>;
+  }
+  return <>{children}</>;
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export class ErrorBoundary extends React.Component<React.PropsWithChildren, { error?: Error }> {
+  state = { error: undefined as Error | undefined };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  componentDidCatch(error: Error, info: any) {
+    /* log to Sentry or console */
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 24 }}>
+          <h2>Something went wrong</h2>
+          <pre>{this.state.error.message}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AppRoutes from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import AuthProvider from "./auth/AuthProvider";
 import "./style.css";
 
@@ -10,12 +11,14 @@ const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <AppRoutes />
-        </AuthProvider>
-      </QueryClientProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <AppRoutes />
+          </AuthProvider>
+        </QueryClientProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getAllowedEmails } from "./env";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getAllowedEmails", () => {
+  it("parses JSON array", () => {
+    vi.stubEnv("VITE_ALLOWED_EMAILS", '["a@example.com","b@example.com"]');
+    expect(getAllowedEmails()).toEqual(["a@example.com", "b@example.com"]);
+  });
+
+  it("parses CSV list", () => {
+    vi.stubEnv("VITE_ALLOWED_EMAILS", "a@example.com,b@example.com");
+    expect(getAllowedEmails()).toEqual(["a@example.com", "b@example.com"]);
+  });
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,19 @@
+export function getAllowedEmails(): string[] {
+  const raw = import.meta.env.VITE_ALLOWED_EMAILS;
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map(String)
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+  } catch {
+    // fallback to CSV
+  }
+  return String(raw)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Summary
- parse allowed email list from `VITE_ALLOWED_EMAILS`
- gate admin UI by allowed email addresses
- wrap app in error boundary to avoid blank screens
- add unit tests for env parsing and email gating

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b5f78ab304832b839524fb9f3d8cf4