### PR TITLE
Guard bootstrap against non-array collections

### DIFF
--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { getAllowedEmails } from "../utils/env";
+import { safeSome } from "../utils/array";
 
 export function isEmailAllowed(email?: string | null): boolean {
   if (!email) return false;
   const allowed = getAllowedEmails();
-  if (!Array.isArray(allowed) || allowed.length === 0) return false;
-  return allowed.some((x) => x.toLowerCase() === email.toLowerCase());
+  return safeSome(allowed, (x: string) => x.toLowerCase() === email.toLowerCase());
 }
 
 export default function RequireAuth({ user, children }: { user: any; children: React.ReactNode }) {

--- a/src/components/CustomReportGenerator.jsx
+++ b/src/components/CustomReportGenerator.jsx
@@ -8,6 +8,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import Papa from 'papaparse';
 import { http } from '../api/http';
+import { safeIncludes } from '../utils/array';
 
 function CustomReportGenerator() {
   const [startDate, setStartDate] = useState(dayjs().subtract(7, 'day'));
@@ -42,7 +43,7 @@ function CustomReportGenerator() {
     const date = dayjs(item.date);
     return date.isAfter(startDate.subtract(1, 'day')) &&
            date.isBefore(endDate.add(1, 'day')) &&
-           (selectedListings.length === 0 || selectedListings.includes(item.listing));
+           (selectedListings.length === 0 || safeIncludes(selectedListings, item.listing));
   });
 
   const exportToPDF = () => {

--- a/src/components/MultiCalendarEarningsReport.jsx
+++ b/src/components/MultiCalendarEarningsReport.jsx
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import { Box, Typography, Paper, Chip } from '@mui/material';
 import { http } from '../api/http';
+import { safeFind } from '../utils/array';
 
 const startDate = dayjs().startOf('month');
 const numberOfDays = 10;
 const days = [...Array(numberOfDays)].map((_, i) => startDate.add(i, 'day').format('YYYY-MM-DD'));
 
 function isBookedOn(listing, date) {
-  const bookings = Array.isArray(listing.bookings) ? listing.bookings : [];
-  return bookings.find(b =>
+  return safeFind(listing?.bookings, (b) =>
     dayjs(date).isBetween(b.start, b.end, 'day', '[]')
   );
 }

--- a/src/components/SingleCalendarEarningsReport.jsx
+++ b/src/components/SingleCalendarEarningsReport.jsx
@@ -13,6 +13,7 @@ import {
   parseISO,
 } from 'date-fns';
 import { computeThresholds, getHighlightStyle } from '../utils/percentile';
+import { safeFind } from '../utils/array';
 
 const SOURCE_COLORS = {
   airbnb: '#00a1e0',
@@ -76,7 +77,7 @@ function SingleCalendarEarningsReport() {
         setListings(validListings);
 
         const defaultListing =
-          validListings.find((l) => l.name.toLowerCase().includes('ph')) ||
+          safeFind(validListings, (l) => l.name.toLowerCase().includes('ph')) ||
           validListings[0];
 
         if (defaultListing?.listingId) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,11 @@ import "./style.css";
 
 const queryClient = new QueryClient();
 
+if (import.meta.env.PROD) {
+  // eslint-disable-next-line no-console
+  console.log("diag: typeof AppRoutes", typeof AppRoutes);
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ErrorBoundary>

--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -13,6 +13,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import '../style.css';
 import { buildBookingPayload } from '../utils/buildBookingPayload';
 import GuestAutocomplete from '../components/GuestAutocomplete';
+import { safeFind } from '../utils/array';
 
 const Bookings = () => {
   const [listings, setListings] = useState([]);
@@ -236,7 +237,7 @@ const Bookings = () => {
     console.log('Editing booking', bookingToEdit);
     setFormMode('edit');
     setSelectedBookingId(bookingToEdit.id);
-    const listingObj = listings.find(l => l.id === bookingToEdit.listingId) || null;
+    const listingObj = safeFind(listings, (l) => l.id === bookingToEdit.listingId) || null;
     setBooking({
       id: bookingToEdit.id,
       listingId: bookingToEdit.listingId || '',
@@ -280,7 +281,7 @@ const Bookings = () => {
   // Filtering logic
   const filteredBookings = bookings.filter(b => {
     const guestObj = b.guest || {};
-    const listingObj = listings.find(l => l.id === b.listingId) || {};
+    const listingObj = safeFind(listings, (l) => l.id === b.listingId) || {};
     return (
       (!filters.listing || listingObj.name?.toLowerCase().includes(filters.listing.toLowerCase())) &&
       (!filters.guest || guestObj.name?.toLowerCase().includes(filters.guest.toLowerCase()))
@@ -673,10 +674,10 @@ const Bookings = () => {
           <TableBody>
             {paginatedBookings.map(row => {
               const guestObj = row.guest || {};
-              const listingObj = listings.find(l => l.id === row.listingId) || {};
+              const listingObj = safeFind(listings, (l) => l.id === row.listingId) || {};
               const bankAccountObj =
                 row.bankAccount ||
-                bankAccounts.find(b => b.id === row.bankAccountId) ||
+                safeFind(bankAccounts, (b) => b.id === row.bankAccountId) ||
                 {};
               const bankName = bankAccountObj?.bankName || '';
               const accountNumber = bankAccountObj?.accountNumber || '';

--- a/src/pages/Listings.jsx
+++ b/src/pages/Listings.jsx
@@ -5,6 +5,7 @@ import {
   TableBody, Paper, Grid, Alert
 } from '@mui/material';
 import { http } from '../api/http';
+import { safeFind } from '../utils/array';
 
 const Listings = () => {
   const [listings, setListings] = useState([]);
@@ -322,7 +323,7 @@ const Listings = () => {
           <TableBody>
             {listings.map(l => (
               <TableRow key={l.id}>
-                <TableCell>{properties.find(p => p.id === l.propertyId)?.name || '—'}</TableCell>
+                <TableCell>{safeFind(properties, (p) => p.id === l.propertyId)?.name || '—'}</TableCell>
                 <TableCell>{l.name}</TableCell>
                 <TableCell>{l.floor}</TableCell>
                 <TableCell>{l.type}</TableCell>

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,23 @@
+export function toArray<T>(val: T | T[] | null | undefined): T[] {
+  if (Array.isArray(val)) return val;
+  if (val === null || val === undefined) return [];
+  return [val];
+}
+export function safeFind<T>(
+  xs: unknown,
+  predicate: (x: T, i: number, a: T[]) => boolean
+): T | undefined {
+  return Array.isArray(xs) ? xs.find(predicate) : undefined;
+}
+export function safeSome<T>(
+  xs: unknown,
+  predicate: (x: T, i: number, a: T[]) => boolean
+): boolean {
+  return Array.isArray(xs) ? xs.some(predicate) : false;
+}
+export function safeIncludes<T extends string | number>(
+  xs: unknown,
+  value: T
+): boolean {
+  return Array.isArray(xs) ? (xs as T[]).includes(value) : false;
+}


### PR DESCRIPTION
## Summary
- add array helpers (safeFind/safeSome/safeIncludes/toArray)
- replace fragile `.find` calls in listings, bookings, reports, auth, and custom report generator
- log type of AppRoutes at bootstrap for prod diagnostics

## Testing
- `npm test -- --run`
- `npm run build` *(fails: Rollup failed to resolve import "@tanstack/react-query" from /workspace/atlas-admin-portal/src/main.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa96cb7c832bb07d30ce8a487217