### PR TITLE
Render booking guest name with fallback

### DIFF
--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -673,24 +673,26 @@ const Bookings = () => {
           </TableHead>
           <TableBody>
             {paginatedBookings.map(row => {
-              const guestObj = row.guest || {};
               const listingObj = safeFind(listings, (l) => l.id === row.listingId) || {};
               const bankAccountObj =
                 row.bankAccount ||
                 safeFind(bankAccounts, (b) => b.id === row.bankAccountId) ||
                 {};
-              const bankName = bankAccountObj?.bankName || '';
-              const accountNumber = bankAccountObj?.accountNumber || '';
-              const prefix = bankName.slice(0, 4).toUpperCase();
-              const suffix = accountNumber.slice(-4);
-              const formattedBank = `${prefix}-${suffix}`;
+              const bankName = (bankAccountObj?.bankName ?? '').toString();
+              const accountNumber = (bankAccountObj?.accountNumber ?? '').toString();
+              const prefix = bankName ? bankName.slice(0, 4).toUpperCase() : '';
+              const suffix = accountNumber ? accountNumber.slice(-4) : '';
+              const formattedBank = prefix && suffix ? `${prefix}-${suffix}` : '';
+              const guestName  = (row.guest?.name ?? row.guestName ?? '').trim();
+              const guestPhone = (row.guest?.phone ?? row.guestPhone ?? '').trim();
+              const guestEmail = (row.guest?.email ?? row.guestEmail ?? '').trim();
               return (
                 <TableRow key={row.id}>
                   <TableCell>{listingObj.name || row.listingId}</TableCell>
                   <TableCell>
-                    {guestObj.name || ''}<br />
-                    {guestObj.phone || ''}<br />
-                    {guestObj.email || ''}
+                    {guestName || '—'}<br />
+                    {guestPhone || ''}<br />
+                    {guestEmail || ''}
                   </TableCell>
                   <TableCell>{displayDate(row.checkinDate || row.checkInDate)}</TableCell>
                   <TableCell>{displayDate(row.checkoutDate || row.checkOutDate)}</TableCell>

--- a/src/types/bookings.ts
+++ b/src/types/bookings.ts
@@ -1,0 +1,22 @@
+export interface Booking {
+  id: number;
+  listingId: number;
+  guestId: number;
+  checkinDate: string;
+  checkoutDate: string;
+  paymentStatus: string;
+  bookingSource: string;
+  guestsPlanned: number;
+  guestsActual: number;
+  extraGuestCharge: number;
+  commissionAmount: number;
+  amountReceived: number;
+  bankAccountId?: number | null;
+  bankAccount?: { bankName?: string; accountNumber?: string } | null;
+  // NEW (from API projection)
+  guestName?: string | null;
+  guestPhone?: string | null;
+  guestEmail?: string | null;
+  // keep existing optional nested guest if it ever arrives
+  guest?: { name?: string; phone?: string; email?: string } | null;
+}


### PR DESCRIPTION
## Summary
- Add Booking type with guest name, phone, and email projections
- Render guest details from guestName/guestPhone/guestEmail with bank formatting guard

## Testing
- `npx vitest run`
- `curl -sSf http://localhost:3000/bookings` *(fails: couldn't connect)*

------
https://chatgpt.com/codex/tasks/task_e_68b6106525c8832bbb327c82c017bef1