### PR TITLE
Fix guest typeahead re-render loop

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,9 @@ import { getApiBase, getGuestSearchMode } from "@/utils/env";
 if (import.meta.env.DEV) {
   // eslint-disable-next-line no-console
   console.log('apiBase', getApiBase(), 'guestSearchMode', getGuestSearchMode());
+} else if (import.meta.env.PROD && getApiBase().includes('localhost')) {
+  // eslint-disable-next-line no-console
+  console.warn('apiBase points to localhost in production');
 }
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
## Summary
- stabilize guest search hook and debounce text input
- decouple selected guest from typed text in GuestTypeahead
- warn if production build points to localhost API

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b69c007394832b9be060cde4629fac