### PR TITLE
Simplify booking table rendering

### DIFF
--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -13,7 +13,6 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import '../style.css';
 import { buildBookingPayload } from '../utils/buildBookingPayload';
 import GuestTypeahead from '../components/GuestTypeahead';
-import { safeFind } from '../utils/array';
 
 const Bookings = () => {
   const [listings, setListings] = useState([]);
@@ -65,8 +64,6 @@ const Bookings = () => {
   const nights = booking.checkinDate && booking.checkoutDate
     ? dayjs(booking.checkoutDate).diff(dayjs(booking.checkinDate), 'day')
     : 0;
-  const displayDate = (dateStr) =>
-    dateStr ? dayjs(dateStr).format('YYYY-MM-DD') : '';
   const handleChangePage = (event, newPage) => {
     setPage(newPage);
   };
@@ -123,9 +120,9 @@ const Bookings = () => {
     setIsLoading(true);
     setFetchError('');
     try {
-        let url = `/bookings?include=bankAccount,guest`;
+        let url = `/bookings`;
         if (start && end) {
-          url += `&checkinStart=${dayjs(start).format('YYYY-MM-DD')}&checkinEnd=${dayjs(end).format('YYYY-MM-DD')}`;
+          url += `?checkinStart=${dayjs(start).format('YYYY-MM-DD')}&checkinEnd=${dayjs(end).format('YYYY-MM-DD')}`;
         }
         const { data } = await api.get(url);
       const sorted = [...asArray(data, 'bookings')].sort(
@@ -237,7 +234,7 @@ const Bookings = () => {
     console.log('Editing booking', bookingToEdit);
     setFormMode('edit');
     setSelectedBookingId(bookingToEdit.id);
-    const listingObj = safeFind(listings, (l) => l.id === bookingToEdit.listingId) || null;
+    const listingObj = listings.find(l => l.id === bookingToEdit.listingId) || null;
     setBooking({
       id: bookingToEdit.id,
       listingId: bookingToEdit.listingId || '',
@@ -259,7 +256,11 @@ const Bookings = () => {
     setExtraGuestCharge(bookingToEdit.extraGuestCharge ?? 0);
     setShowExtras(!!bookingToEdit.guestsPlanned || !!bookingToEdit.guestsActual || !!bookingToEdit.extraGuestCharge);
     setSelectedGuestId(bookingToEdit.guestId.toString());
-    const guestObj = bookingToEdit.guest || { name: '', phone: '', email: '' };
+    const guestObj = {
+      name: bookingToEdit.guest || '',
+      phone: bookingToEdit.guestPhone || '',
+      email: bookingToEdit.guestEmail || ''
+    };
     setGuest(guestObj);
     setSelectedGuest(guestObj);
     setSelectedListing(listingObj);
@@ -279,14 +280,10 @@ const Bookings = () => {
   };
 
   // Filtering logic
-  const filteredBookings = bookings.filter(b => {
-    const guestObj = b.guest || {};
-    const listingObj = safeFind(listings, (l) => l.id === b.listingId) || {};
-    return (
-      (!filters.listing || listingObj.name?.toLowerCase().includes(filters.listing.toLowerCase())) &&
-      (!filters.guest || guestObj.name?.toLowerCase().includes(filters.guest.toLowerCase()))
-    );
-  });
+  const filteredBookings = bookings.filter(b => (
+    (!filters.listing || (b.listing || '').toLowerCase().includes(filters.listing.toLowerCase())) &&
+    (!filters.guest || (b.guest || '').toLowerCase().includes(filters.guest.toLowerCase()))
+  ));
 
   // Sorting logic
   const sortedBookings = [...filteredBookings].sort((a, b) => {
@@ -668,68 +665,51 @@ const Bookings = () => {
               <TableCell>Net (₹)</TableCell>
               <TableCell>Bank Account</TableCell>
               <TableCell>Source</TableCell>
+              <TableCell>Status</TableCell>
               <TableCell></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {paginatedBookings.map(row => {
-              const listingObj = safeFind(listings, (l) => l.id === row.listingId) || {};
-              const bankAccountObj =
-                row.bankAccount ||
-                safeFind(bankAccounts, (b) => b.id === row.bankAccountId) ||
-                {};
-              const bankName = (bankAccountObj?.bankName ?? '').toString();
-              const accountNumber = (bankAccountObj?.accountNumber ?? '').toString();
-              const prefix = bankName ? bankName.slice(0, 4).toUpperCase() : '';
-              const suffix = accountNumber ? accountNumber.slice(-4) : '';
-              const formattedBank = prefix && suffix ? `${prefix}-${suffix}` : '';
-              const guestName  = (row.guest?.name ?? row.guestName ?? '').trim();
-              const guestPhone = (row.guest?.phone ?? row.guestPhone ?? '').trim();
-              const guestEmail = (row.guest?.email ?? row.guestEmail ?? '').trim();
-              return (
-                <TableRow key={row.id}>
-                  <TableCell>{listingObj.name || row.listingId}</TableCell>
-                  <TableCell>
-                    {guestName || '—'}<br />
-                    {guestPhone || ''}<br />
-                    {guestEmail || ''}
-                  </TableCell>
-                  <TableCell>{displayDate(row.checkinDate || row.checkInDate)}</TableCell>
-                  <TableCell>{displayDate(row.checkoutDate || row.checkOutDate)}</TableCell>
-                  <TableCell>{row.paymentStatus}</TableCell>
-                  <TableCell>{row.guestsPlanned} → {row.guestsActual}</TableCell>
-                  <TableCell>₹{row.extraGuestCharge?.toLocaleString("en-IN")}</TableCell>
-                  <TableCell>₹{row.commissionAmount?.toLocaleString("en-IN", { minimumFractionDigits: 2 })}</TableCell>
-                  <TableCell>₹{row.amountReceived?.toLocaleString("en-IN")}</TableCell>
-                  <TableCell>{formattedBank}</TableCell>
-                  <TableCell>{row.bookingSource}</TableCell>
-                  <TableCell>
-                    <Box sx={{ display: 'flex', gap: 1 }}>
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        onClick={() => handleEdit(row)}
-                        disabled={loading}
-                        sx={{ minWidth: 60 }}
-                      >
-                        Edit
-                      </Button>
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        color="error"
-                        onClick={() => handleDelete(row.id)}
-                        disabled={loading}
-                        startIcon={<DeleteIcon />}
-                        sx={{ minWidth: 80 }}
-                      >
-                        Delete
-                      </Button>
-                    </Box>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
+            {paginatedBookings.map(row => (
+              <TableRow key={row.id}>
+                <TableCell>{row.listing}</TableCell>
+                <TableCell>{row.guest}</TableCell>
+                <TableCell>{new Date(row.checkinDate).toLocaleDateString()}</TableCell>
+                <TableCell>{new Date(row.checkoutDate).toLocaleDateString()}</TableCell>
+                <TableCell>₹{row.amountReceived.toLocaleString('en-IN')}</TableCell>
+                <TableCell>{row.guestsActual}</TableCell>
+                <TableCell>₹{row.extraGuestCharge.toLocaleString('en-IN')}</TableCell>
+                <TableCell>₹{row.commissionAmount.toLocaleString('en-IN', { minimumFractionDigits: 2 })}</TableCell>
+                <TableCell>₹{(row.amountReceived - row.commissionAmount).toLocaleString('en-IN')}</TableCell>
+                <TableCell>{row.bankAccount}</TableCell>
+                <TableCell>{row.bookingSource}</TableCell>
+                <TableCell>{row.paymentStatus}</TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={() => handleEdit(row)}
+                      disabled={loading}
+                      sx={{ minWidth: 60 }}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="error"
+                      onClick={() => handleDelete(row.id)}
+                      disabled={loading}
+                      startIcon={<DeleteIcon />}
+                      sx={{ minWidth: 80 }}
+                    >
+                      Delete
+                    </Button>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
 


### PR DESCRIPTION
## Summary
- Render bookings table using flattened `BookingListDto` fields
- Display dates via `toLocaleDateString` and compute net amount directly
- Drop nested lookups in filters and edit flow

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b759e30068832bacf0888a77103a47