### PR TITLE
Handle guest search errors and update API base

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VITE_API_BASE=https://atlas-homes-api-gxdqfjc2btc0atbv.centralus-01.azurewebsites.net
+VITE_API_BASE=http://localhost:5287
 
 # Auth0 configuration
 VITE_AUTH_DISABLED=false


### PR DESCRIPTION
## Summary
- handle rejected guest searches by showing an inline error and resetting loading
- default API base to http for local development

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76130b3a8832bb9f4e589fd4c3eb2