### PR TITLE
Use local backend API base for development

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,4 @@
-VITE_API_BASE=https://atlas-homes-api-gxdqfjc2btc0atbv.centralus-01.azurewebsites.net
+VITE_API_BASE=http://localhost:5287
 
 # Auth0 configuration
 VITE_AUTH_DISABLED=false


### PR DESCRIPTION
## Summary
- point `VITE_API_BASE` to `http://localhost:5287` in `.env.local`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b87c5cf668832ba76c30db1e6efa9d