### PR TITLE
Remove remote guest search mode

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,4 @@
-VITE_API_BASE=https://atlas-homes-api-gxdqfjc2btc0atbv.centralus-01.azurewebsites.net
+VITE_API_BASE=http://localhost:5287
 
 # Auth0 configuration
 VITE_AUTH_DISABLED=false
@@ -7,9 +7,6 @@ VITE_AUTH0_CLIENT_ID=d70OGzWag10f4viX8DI1SxOXAj6aDsvX
 VITE_AUTH0_CALLBACK_PATH=/auth/callback
 VITE_DEFAULT_AFTER_LOGIN=/bookings
 
-# Guest search mode
-VITE_GUEST_SEARCH_MODE=local
-
-# Auth0 configuration
+# Auth bypass settings
 VITE_AUTH_BYPASS=false
 VITE_ALLOWED_EMAILS=atlashomeskphb@gmail.com,sreekar.atla@gmail.com

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If these endpoints are unavailable the application will automatically fall back
 to the standard `/admin/reports/bookings`, `/admin/reports/listings` and
 `/admin/reports/payouts` endpoints.
 
-Set `VITE_GUEST_SEARCH_MODE=local` to enable client-side guest search.
+Guest search is performed client-side using the hydrated guest list.
 
 # Go to the directory where you want to store all repos
 cd ~/Projects/AtlasHomestays  # or any preferred location

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,10 +1,9 @@
-import { getApiBase, getGuestSearchMode } from '@/utils/env';
+import { getApiBase } from '@/utils/env';
 
 export const IS_LOCALHOST = typeof window !== 'undefined' && /^(localhost|127\.0\.0\.1)$/.test(window.location.hostname);
 
 export const ENV = {
   VITE_API_BASE: getApiBase(),
-  VITE_GUEST_SEARCH_MODE: getGuestSearchMode(),
   VITE_AUTH_DISABLED: String(import.meta.env.VITE_AUTH_DISABLED || '').toLowerCase() === 'true',
   VITE_AUTH_BYPASS: String(import.meta.env.VITE_AUTH_BYPASS || '').toLowerCase() === 'true',
   VITE_AUTH0_DOMAIN: import.meta.env.VITE_AUTH0_DOMAIN || '',

--- a/src/hooks/__tests__/useGuestSearch.test.ts
+++ b/src/hooks/__tests__/useGuestSearch.test.ts
@@ -1,22 +1,12 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import axios from 'axios';
 import { useGuestSearch, type Guest } from '../useGuestSearch';
 
-vi.mock('axios');
-const mockedAxios = axios as unknown as { get: ReturnType<typeof vi.fn> };
-
-afterEach(() => {
-  vi.resetAllMocks();
-  vi.unstubAllEnvs();
-});
-
 describe('useGuestSearch', () => {
-  it('filters locally and does not call axios in local mode', async () => {
-    vi.stubEnv('VITE_GUEST_SEARCH_MODE', 'local');
+  it('filters guests locally', async () => {
     const guests: Guest[] = [
       { id: '1', name: 'Lekana', email: 'l@example.com', phone: '123' },
       { id: '2', name: 'Ravi', email: 'r@example.com', phone: '456' },
@@ -24,26 +14,6 @@ describe('useGuestSearch', () => {
     const { result } = renderHook(() => useGuestSearch(guests));
     const res = await result.current('lek');
     expect(res).toEqual([guests[0]]);
-    expect(mockedAxios.get).not.toHaveBeenCalled();
-  });
-
-  it('calls axios in remote mode and returns results', async () => {
-    vi.stubEnv('VITE_GUEST_SEARCH_MODE', 'remote');
-    vi.stubEnv('VITE_API_BASE', 'https://api.test');
-    mockedAxios.get = vi.fn().mockResolvedValue({ data: [{ id: '3', name: 'Neo' }] });
-    const { result } = renderHook(() => useGuestSearch(null));
-    const res = await result.current('neo');
-    expect(mockedAxios.get).toHaveBeenCalledWith('https://api.test/api/guests/search?q=neo', expect.any(Object));
-    expect(res).toEqual([{ id: '3', name: 'Neo' }]);
-  });
-
-  it('falls back to local on remote failure when guests provided', async () => {
-    vi.stubEnv('VITE_GUEST_SEARCH_MODE', 'remote');
-    vi.stubEnv('VITE_API_BASE', 'https://api.test');
-    mockedAxios.get = vi.fn().mockRejectedValue(new Error('network'));
-    const guests: Guest[] = [{ id: '1', name: 'Lekana' }];
-    const { result } = renderHook(() => useGuestSearch(guests));
-    const res = await result.current('lek');
-    expect(res).toEqual([guests[0]]);
   });
 });
+

--- a/src/hooks/useGuestSearch.ts
+++ b/src/hooks/useGuestSearch.ts
@@ -1,18 +1,13 @@
 import { useMemo } from 'react';
-import axios from 'axios';
-import { getApiBase, getGuestSearchMode } from '@/utils/env';
 
 export interface Guest { id: string; name: string; email?: string; phone?: string; }
 
 const norm = (s: string) => s?.toLowerCase().trim() ?? '';
 
 export const useGuestSearch = (allGuests?: Guest[]) => {
-  const mode = getGuestSearchMode();
-  const apiBase = getApiBase();
-
   const localIdx = useMemo(() => allGuests ?? [], [allGuests]);
 
-  const localSearch = useMemo(() => {
+  return useMemo(() => {
     return async (q: string) => {
       const n = norm(q);
       if (!n) return [];
@@ -25,27 +20,5 @@ export const useGuestSearch = (allGuests?: Guest[]) => {
         .slice(0, 50);
     };
   }, [localIdx]);
-
-  const remoteSearch = useMemo(() => {
-    return async (q: string) => {
-      const n = q?.trim();
-      if (!n) return [];
-      const url = `${apiBase}/api/guests/search?q=${encodeURIComponent(n)}`;
-      const { data } = await axios.get<Guest[]>(url, { timeout: 8000 });
-      return Array.isArray(data) ? data : [];
-    };
-  }, [apiBase]);
-
-  return useMemo(() => {
-    if (mode === 'local') return localSearch;
-    return async (q: string) => {
-      try {
-        return await remoteSearch(q);
-      } catch (err) {
-        if (localIdx.length) return localSearch(q);
-        throw err;
-      }
-    };
-  }, [mode, localSearch, remoteSearch, localIdx.length]);
 };
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,2 +1,2 @@
 export { ENV, getAuthConfig, getAllowedEmails, IS_LOCALHOST } from '@/config/env';
-export { getGuestSearchMode, getApiBase } from '@/utils/env';
+export { getApiBase } from '@/utils/env';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,11 @@ import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import AuthProvider from "./auth/AuthProvider";
 import "./style.css";
-import { getApiBase, getGuestSearchMode } from "@/utils/env";
+import { getApiBase } from "@/utils/env";
 
 if (import.meta.env.DEV) {
   // eslint-disable-next-line no-console
-  console.log('apiBase', getApiBase(), 'guestSearchMode', getGuestSearchMode());
+  console.log('apiBase', getApiBase());
 } else if (import.meta.env.PROD && getApiBase().includes('localhost')) {
   // eslint-disable-next-line no-console
   console.warn('apiBase points to localhost in production');

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,10 +1,3 @@
-export type GuestSearchMode = 'local' | 'remote';
-
-export const getGuestSearchMode = (): GuestSearchMode => {
-  const raw = (import.meta.env.VITE_GUEST_SEARCH_MODE ?? 'local').toString().trim().toLowerCase();
-  return raw === 'remote' ? 'remote' : 'local';
-};
-
 export const getApiBase = (): string => {
   const raw = (import.meta.env.VITE_API_BASE ?? '').trim();
   if (import.meta.env.PROD && /localhost/i.test(raw)) {


### PR DESCRIPTION
## Summary
- drop remote guest search and rely solely on local data
- remove `VITE_GUEST_SEARCH_MODE` from configuration and docs
- point `VITE_API_BASE` to `http://localhost:5287` in `.env.local`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b87c5cf668832ba76c30db1e6efa9d