### PR TITLE
fix: handle missing guest contact info in search

### DIFF
--- a/src/hooks/__tests__/useGuestSearch.test.ts
+++ b/src/hooks/__tests__/useGuestSearch.test.ts
@@ -15,5 +15,16 @@ describe('useGuestSearch', () => {
     const res = await result.current('lek');
     expect(res).toEqual([guests[0]]);
   });
+
+  it('handles guests missing email or phone', async () => {
+    const guests: Guest[] = [
+      { id: '1', name: 'Alpha' },
+      { id: '2', name: 'Beta', email: 'b@example.com' },
+      { id: '3', name: 'Gamma', phone: '789' },
+    ];
+    const { result } = renderHook(() => useGuestSearch(guests));
+    const res = await result.current('gam');
+    expect(res).toEqual([guests[2]]);
+  });
 });
 

--- a/src/hooks/useGuestSearch.ts
+++ b/src/hooks/useGuestSearch.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 export interface Guest { id: string; name: string; email?: string; phone?: string; }
 
-const norm = (s: string) => s?.toLowerCase().trim() ?? '';
+const norm = (s?: string) => (s ?? '').toLowerCase().trim();
 
 export const useGuestSearch = (allGuests?: Guest[]) => {
   const localIdx = useMemo(() => allGuests ?? [], [allGuests]);


### PR DESCRIPTION
## Summary
- normalize optional guest fields safely during search
- cover guest search without email or phone in tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bce89681ac832ba262d09b82165c0a