### PR TITLE
fix: handle missing guest contact info in search

### DIFF
--- a/src/hooks/__tests__/useGuestSearch.test.ts
+++ b/src/hooks/__tests__/useGuestSearch.test.ts
@@ -15,5 +15,23 @@ describe('useGuestSearch', () => {
     const res = await result.current('lek');
     expect(res).toEqual([guests[0]]);
   });
+
+  it('handles guests missing email or phone', async () => {
+    const guests: Guest[] = [
+      { id: '1', name: 'Alpha' },
+      { id: '2', name: 'Beta', email: 'b@example.com' },
+      { id: '3', name: 'Gamma', phone: '789' },
+    ];
+    const { result } = renderHook(() => useGuestSearch(guests));
+    const res = await result.current('gam');
+    expect(res).toEqual([guests[2]]);
+  });
+
+  it('ignores null or undefined guest entries', async () => {
+    const guests: any[] = [undefined, { id: '1', name: 'Alpha' }, null];
+    const { result } = renderHook(() => useGuestSearch(guests as Guest[]));
+    const res = await result.current('alpha');
+    expect(res).toEqual([{ id: '1', name: 'Alpha' }]);
+  });
 });
 

--- a/src/hooks/useGuestSearch.ts
+++ b/src/hooks/useGuestSearch.ts
@@ -2,10 +2,13 @@ import { useMemo } from 'react';
 
 export interface Guest { id: string; name: string; email?: string; phone?: string; }
 
-const norm = (s: string) => s?.toLowerCase().trim() ?? '';
+const norm = (s?: string) => (s ?? '').toLowerCase().trim();
 
 export const useGuestSearch = (allGuests?: Guest[]) => {
-  const localIdx = useMemo(() => allGuests ?? [], [allGuests]);
+  const localIdx = useMemo(
+    () => (allGuests ?? []).filter((g): g is Guest => Boolean(g)),
+    [allGuests]
+  );
 
   return useMemo(() => {
     return async (q: string) => {

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,1 +1,2 @@
-export const normalize = (s: string) => s?.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
+export const normalize = (s?: string) =>
+  (s ?? '').normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();


### PR DESCRIPTION
## Summary
- normalize optional guest fields safely during search
- cover guest search without email or phone in tests
- skip invalid guest entries and broaden normalization util

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bce89681ac832ba262d09b82165c0a