### PR TITLE
Use guest IDs as keys in typeahead options

### DIFF
--- a/src/components/GuestTypeahead.tsx
+++ b/src/components/GuestTypeahead.tsx
@@ -88,6 +88,11 @@ export default function GuestTypeahead({ allGuests = [], onSelect }: Props) {
       }}
       getOptionLabel={o => o?.name ?? ''}
       filterOptions={x => x}
+      renderOption={(props, option) => (
+        <li {...props} key={option.id}>
+          {option.name}
+        </li>
+      )}
       renderInput={params => (
         <TextField
           {...params}


### PR DESCRIPTION
## Summary
- fix duplicate key warnings in GuestTypeahead by using guest ID as option key

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68bd7eb31a9c832bad0f1899eb63fa68