### PR TITLE
Add ability to create new guest from typeahead

### DIFF
--- a/src/components/GuestTypeahead.test.tsx
+++ b/src/components/GuestTypeahead.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import GuestTypeahead from './GuestTypeahead';
+
+describe('GuestTypeahead', () => {
+  it('shows "Add new guest" when no matches and triggers onAddNew', async () => {
+    const user = userEvent.setup();
+    const onAddNew = vi.fn();
+    render(<GuestTypeahead allGuests={[]} onSelect={() => {}} onAddNew={onAddNew} />);
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'Bob');
+    await new Promise(r => setTimeout(r, 350));
+    const addNew = await screen.findByText(/Add new guest/i);
+    await user.click(addNew);
+    expect(onAddNew).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- show an `Add new guest` option in `GuestTypeahead` when no matches are found
- trigger optional `onAddNew` callback when the option is chosen
- cover add-new-guest flow with a component test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd84226f98832ba974da99f56aac1f