### PR TITLE
Fix guest typeahead selection and refresh

### DIFF
--- a/src/components/GuestTypeahead.test.tsx
+++ b/src/components/GuestTypeahead.test.tsx
@@ -2,12 +2,13 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import GuestTypeahead from './GuestTypeahead';
 
 describe('GuestTypeahead', () => {
+  afterEach(() => cleanup());
   it('shows "Add new guest" when no matches and triggers onAddNew', async () => {
     const user = userEvent.setup();
     const onAddNew = vi.fn();
@@ -18,5 +19,12 @@ describe('GuestTypeahead', () => {
     const addNew = await screen.findByText(/Add new guest/i);
     await user.click(addNew);
     expect(onAddNew).toHaveBeenCalled();
+  });
+
+  it('displays the provided value', () => {
+    const guest = { id: '1', name: 'Alice' } as any;
+    render(<GuestTypeahead allGuests={[guest]} value={guest} onSelect={() => {}} />);
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input.value).toBe('Alice');
   });
 });

--- a/src/components/GuestTypeahead.tsx
+++ b/src/components/GuestTypeahead.tsx
@@ -4,6 +4,12 @@ import { useGuestSearch, type Guest } from '@/hooks/useGuestSearch';
 
 type Props = {
   allGuests?: Guest[];
+  /**
+   * Currently selected guest.  When provided the component becomes
+   * controlled by the parent so it can update the displayed value when a new
+   * guest is created outside of the Autocomplete.
+   */
+  value?: Guest | null;
   onSelect: (g: Guest | null) => void;
   /**
    * Called when the user wants to create a guest that doesn't exist yet.
@@ -15,15 +21,23 @@ type GuestOption = Guest | { id: string; name: string; isAddNew: true };
 
 export default function GuestTypeahead({
   allGuests = [],
+  value: selectedGuest = null,
   onSelect,
   onAddNew,
 }: Props) {
   const search = useGuestSearch(allGuests);
-  const [value, setValue] = React.useState<Guest | null>(null);
+  const [value, setValue] = React.useState<Guest | null>(selectedGuest);
   const [inputValue, setInputValue] = React.useState('');
   const [options, setOptions] = React.useState<Guest[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+
+  // Keep internal state in sync with the value passed in by the parent.  This
+  // allows consumers to programmatically set the selected guest (e.g. after
+  // creating a new guest via a modal).
+  React.useEffect(() => {
+    setValue(selectedGuest);
+  }, [selectedGuest]);
 
   const debouncedText = useDebouncedValue(inputValue, 300);
 

--- a/src/hooks/__tests__/useGuestSearch.test.ts
+++ b/src/hooks/__tests__/useGuestSearch.test.ts
@@ -32,5 +32,15 @@ describe('useGuestSearch', () => {
     const res = await result.current('alpha');
     expect(res).toEqual([{ id: '1', name: 'Alpha' }]);
   });
+
+  it('matches regardless of letter case', async () => {
+    const guests: Guest[] = [
+      { id: '1', name: 'Charlie' },
+      { id: '2', name: 'Delta' },
+    ];
+    const { result } = renderHook(() => useGuestSearch(guests));
+    const res = await result.current('cHa');
+    expect(res).toEqual([guests[0]]);
+  });
 });
 

--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -123,11 +123,18 @@ const Bookings = () => {
       try {
         const res = await api.post(`/guests`, newGuest);
         const g = res.data;
-      setGuest({ name: g.name, phone: g.phone || '', email: g.email || '' });
-      setSelectedGuestId(g.id.toString());
-      setSelectedGuest(g);
-      setAddGuestOpen(false);
-    } catch (err) {
+
+        // Refresh the local guest cache so that future searches include the
+        // newly added guest and so other pages see the update.
+        await hydrateGuests(true);
+        const all = await getAllGuests();
+        setGuests(all);
+
+        setGuest({ name: g.name, phone: g.phone || '', email: g.email || '' });
+        setSelectedGuestId(g.id.toString());
+        setSelectedGuest(g);
+        setAddGuestOpen(false);
+      } catch (err) {
       console.error(err);
     }
   };
@@ -374,6 +381,7 @@ const Bookings = () => {
               {/* Guest */}
               <GuestTypeahead
                 allGuests={guests}
+                value={selectedGuest}
                 onSelect={(g) => {
                   if (g) {
                     setSelectedGuestId(g.id.toString());

--- a/src/pages/Guests.jsx
+++ b/src/pages/Guests.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { api, asArray } from '@/lib/api';
+import { hydrateGuests } from '@/services/guests.local';
 import {
   Box,
   Button,
@@ -85,6 +86,9 @@ const Guests = () => {
         } else {
           await api.post(`/guests`, form);
         }
+      // Ensure the bookings page sees the latest guests by refreshing the
+      // cached list used for typeahead search.
+      await hydrateGuests(true);
       handleClose();
       fetchGuests();
     } catch (err) {
@@ -99,6 +103,7 @@ const Guests = () => {
     setError('');
     try {
         await api.delete(`/guests/${id}`);
+      await hydrateGuests(true);
       fetchGuests();
     } catch (err) {
       setError('Failed to delete guest.');


### PR DESCRIPTION
## Summary
- Ensure GuestTypeahead can display externally set value so newly created guests populate correctly
- Refresh local guest cache when creating, editing, or deleting guests to keep bookings search current
- Add case-insensitive guest search test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be810b6224832b9ef64c9385b640d2