### PR TITLE
Fix booking edit form to hydrate saved selections

### DIFF
--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -23,7 +23,6 @@ const Bookings = () => {
   const [guests, setGuests] = useState([]);
   const [selectedGuestId, setSelectedGuestId] = useState('');
   const [selectedGuest, setSelectedGuest] = useState(null);
-  const [selectedListing, setSelectedListing] = useState(null);
   const [guest, setGuest] = useState({ name: '', phone: '', email: '' });
   const [addGuestOpen, setAddGuestOpen] = useState(false);
   const [newGuest, setNewGuest] = useState({ name: '', phone: '', email: '' });
@@ -64,6 +63,7 @@ const Bookings = () => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const messageRef = useRef(null);
+  const lastFetchedGuestIdRef = useRef(null);
   const nights = booking.checkinDate && booking.checkoutDate
     ? dayjs(booking.checkoutDate).diff(dayjs(booking.checkinDate), 'day')
     : 0;
@@ -115,30 +115,78 @@ const Bookings = () => {
   }, []);
 
   useEffect(() => {
-    if (formMode !== 'edit') return;
-    if (!booking.listingId || !listings.length) return;
-    const match = listings.find(
-      l => String(l.id) === String(booking.listingId)
-    );
-    if (match && String(selectedListing?.id) !== String(match.id)) {
-      setSelectedListing(match);
+    if (!selectedGuestId) {
+      lastFetchedGuestIdRef.current = null;
+      return;
     }
-  }, [formMode, booking.listingId, listings, selectedListing]);
 
-  useEffect(() => {
-    if (formMode !== 'edit') return;
-    if (!selectedGuestId || !guests.length) return;
     const match = guests.find(
       g => String(g.id) === String(selectedGuestId)
     );
-    if (match && String(selectedGuest?.id) !== String(match.id)) {
-      setSelectedGuest(match);
+
+    if (match) {
+      lastFetchedGuestIdRef.current = null;
+      if (!selectedGuest || String(selectedGuest.id) !== String(match.id)) {
+        setSelectedGuest(match);
+      }
       setGuest({
         name: match.name || '',
         phone: match.phone || '',
         email: match.email || ''
       });
+      return;
     }
+
+    if (formMode !== 'edit') return;
+
+    if (lastFetchedGuestIdRef.current === selectedGuestId) {
+      if (selectedGuest && String(selectedGuest.id) === String(selectedGuestId)) {
+        setGuest({
+          name: selectedGuest.name || '',
+          phone: selectedGuest.phone || '',
+          email: selectedGuest.email || ''
+        });
+      }
+      return;
+    }
+
+    lastFetchedGuestIdRef.current = selectedGuestId;
+    let active = true;
+    const fetchGuest = async () => {
+      try {
+        const { data } = await api.get(`/guests/${selectedGuestId}`);
+        if (!active) return;
+        const raw = data?.guest ?? data;
+        if (!raw) return;
+        const normalized = {
+          id: raw.id != null ? raw.id.toString() : selectedGuestId,
+          name: raw.name ?? raw.fullName ?? '',
+          phone: raw.phone ?? '',
+          email: raw.email ?? ''
+        };
+        setSelectedGuest(normalized);
+        setGuest({
+          name: normalized.name || '',
+          phone: normalized.phone || '',
+          email: normalized.email || ''
+        });
+        setGuests(prev => {
+          const idx = prev.findIndex(g => String(g.id) === String(normalized.id));
+          if (idx === -1) {
+            return [...prev, normalized];
+          }
+          const next = [...prev];
+          next[idx] = { ...next[idx], ...normalized };
+          return next;
+        });
+      } catch (err) {
+        console.error('Failed to fetch guest details', err);
+      }
+    };
+    fetchGuest();
+    return () => {
+      active = false;
+    };
   }, [formMode, guests, selectedGuestId, selectedGuest]);
 
   const handleAddNewGuest = () => {
@@ -209,7 +257,7 @@ const Bookings = () => {
     setGuest({ name: '', phone: '', email: '' });
     setSelectedGuestId('');
     setSelectedGuest(null);
-    setSelectedListing(null);
+    lastFetchedGuestIdRef.current = null;
     setFormMode('create');
     setSelectedBookingId(null);
     setBooking({
@@ -237,8 +285,9 @@ const Bookings = () => {
     setSuccessMsg('');
     setErrorMsg('');
     try {
-      const guestId = Number(selectedGuestId);
-      const listingId = selectedListing ? selectedListing.id : parseInt(booking.listingId);
+      const guestIdRaw = selectedGuest?.id ?? selectedGuestId;
+      const guestId = guestIdRaw ? Number(guestIdRaw) : NaN;
+      const listingId = booking.listingId ? Number(booking.listingId) : NaN;
 
       if (!guestId || !listingId || !booking.checkinDate || !booking.checkoutDate) {
         setErrorMsg('Please fill in all required fields.');
@@ -250,7 +299,6 @@ const Bookings = () => {
         booking,
         selectedGuest,
         selectedGuestId,
-        selectedListing,
         guestsPlanned,
         guestsActual,
         extraGuestCharge
@@ -284,12 +332,10 @@ const Bookings = () => {
     console.log('Editing booking', bookingToEdit);
     setFormMode('edit');
     setSelectedBookingId(bookingToEdit.id);
-    const listingObj = listings.find(
-      l => String(l.id) === String(bookingToEdit.listingId)
-    ) || null;
+    lastFetchedGuestIdRef.current = null;
     setBooking({
       id: bookingToEdit.id,
-      listingId: bookingToEdit.listingId || '',
+      listingId: bookingToEdit.listingId ? String(bookingToEdit.listingId) : '',
       // Support both camelCase variations returned from the API
       checkinDate: (bookingToEdit.checkinDate || bookingToEdit.checkInDate)
         ? dayjs(bookingToEdit.checkinDate || bookingToEdit.checkInDate).format('YYYY-MM-DD')
@@ -310,20 +356,20 @@ const Bookings = () => {
     const guestFromList = guests.find(
       g => String(g.id) === String(bookingToEdit.guestId)
     ) || null;
-    const guestObj = guestFromList || {
-      id: bookingToEdit.guestId?.toString() || '',
+    const fallbackGuest = {
+      id: bookingToEdit.guestId != null ? bookingToEdit.guestId.toString() : '',
       name: bookingToEdit.guest || '',
       phone: bookingToEdit.guestPhone || '',
       email: bookingToEdit.guestEmail || ''
     };
-    setSelectedGuestId(guestObj.id?.toString() || '');
+    const guestObj = guestFromList || (fallbackGuest.id ? fallbackGuest : null);
+    setSelectedGuestId(guestObj?.id?.toString() || '');
     setGuest({
-      name: guestObj.name || '',
-      phone: guestObj.phone || '',
-      email: guestObj.email || ''
+      name: guestObj?.name || '',
+      phone: guestObj?.phone || '',
+      email: guestObj?.email || ''
     });
     setSelectedGuest(guestObj);
-    setSelectedListing(listingObj);
     setSuccessMsg('');
   };
 
@@ -453,18 +499,21 @@ const Bookings = () => {
               <FormControl required>
                 <InputLabel>Listing</InputLabel>
                 <Select
-                  value={selectedListing || ''}
+                  value={booking.listingId || ''}
                   onChange={e => {
-                    const val = e.target.value;
-                    setSelectedListing(val || null);
-                    setBooking({ ...booking, listingId: val ? val.id : '' });
+                    const val = e.target.value === '' ? '' : e.target.value.toString();
+                    setBooking({ ...booking, listingId: val });
                   }}
                   label="Listing"
-                  renderValue={(selected) => selected?.name || ''}
+                  renderValue={(selectedId) => {
+                    if (!selectedId) return '';
+                    const match = listings.find(l => String(l.id) === String(selectedId));
+                    return match?.name || '';
+                  }}
                 >
                   <MenuItem value="">Select Listing</MenuItem>
                   {listings.map(l => (
-                    <MenuItem key={l.id} value={l}>{l.name}</MenuItem>
+                    <MenuItem key={l.id} value={l.id != null ? l.id.toString() : ''}>{l.name}</MenuItem>
                   ))}
                 </Select>
               </FormControl>

--- a/src/utils/buildBookingPayload.js
+++ b/src/utils/buildBookingPayload.js
@@ -2,7 +2,6 @@ export function buildBookingPayload({
   booking,
   selectedGuest,
   selectedGuestId,
-  selectedListing,
   guestsPlanned,
   guestsActual,
   extraGuestCharge
@@ -10,12 +9,15 @@ export function buildBookingPayload({
   let guestId = selectedGuest ? selectedGuest.id : selectedGuestId;
   guestId = Number(guestId);
 
-  const listingId = selectedListing ? selectedListing.id : parseInt(booking.listingId);
+  const listingId = booking?.listingId != null && booking.listingId !== ''
+    ? Number(booking.listingId)
+    : undefined;
+  const normalizedListingId = Number.isFinite(listingId) ? listingId : null;
 
   return {
     ...booking,
-    guestId: guestId,
-    listingId: Number(listingId),
+    guestId,
+    listingId: normalizedListingId,
     notes: booking.notes?.trim() || '-',
     bankAccountId: booking.bankAccountId ? parseInt(booking.bankAccountId) : null,
     commissionAmount: parseFloat(booking.commissionAmount),

--- a/src/utils/buildBookingPayload.test.js
+++ b/src/utils/buildBookingPayload.test.js
@@ -5,7 +5,7 @@ describe('buildBookingPayload', () => {
   it('constructs payload with guest and listing ids and defaults notes', () => {
     const booking = {
       id: 1,
-      listingId: '',
+      listingId: '3',
       checkinDate: '2024-01-01',
       checkoutDate: '2024-01-02',
       bookingSource: 'Walk-in',
@@ -19,7 +19,6 @@ describe('buildBookingPayload', () => {
       booking,
       selectedGuest: { id: 5, name: 'John' },
       selectedGuestId: '',
-      selectedListing: { id: 3, name: 'Villa' },
       guestsPlanned: 2,
       guestsActual: 2,
       extraGuestCharge: 0


### PR DESCRIPTION
## Summary
- populate the booking edit form by reusing the saved guest id and fetching full guest details so contact fields auto-fill
- standardize listing selection to rely on the stored listing id and reset edit state when switching modes
- update the booking payload builder and its unit test to read the listing id from the booking state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccde8dcd50832b9267d3facc0c20e7